### PR TITLE
Add KPI reporting and validation workflow

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -1,0 +1,20 @@
+name: validation
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  kpi-report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Run KPI report
+        run: python scripts/report_kpis.py

--- a/core/kns/metrics/kpis_consolidacion.md
+++ b/core/kns/metrics/kpis_consolidacion.md
@@ -1,0 +1,9 @@
+# KPIs de Consolidación
+
+| KPI | Resultado |
+| --- | --- |
+| % de README completos (status "OK") | 90.70% (78/86) |
+| Directorios con naming válido | 197/223 |
+| Referencias cruzadas actualizadas al glosario | 0/2 |
+
+Generado con `scripts/report_kpis.py`.

--- a/scripts/report_kpis.py
+++ b/scripts/report_kpis.py
@@ -1,0 +1,74 @@
+import os
+import re
+from pathlib import Path
+
+OK_STATUSES = {"OK", "ACTUALIZADO"}
+
+
+def readme_kpi(root: Path) -> tuple[float, int, int]:
+    readmes = list(root.rglob("README.md"))
+    total = len(readmes)
+    ok = 0
+    status_pattern = re.compile(r"\*\*STATUS:\*\*\s*`([^`]+)`", re.IGNORECASE)
+    for path in readmes:
+        try:
+            with path.open(encoding="utf-8") as fh:
+                for line in fh:
+                    m = status_pattern.search(line)
+                    if m:
+                        if m.group(1).strip().upper() in OK_STATUSES:
+                            ok += 1
+                        break
+        except Exception:
+            pass
+    percent = (ok / total * 100) if total else 0.0
+    return percent, ok, total
+
+
+def directory_naming_kpi(root: Path) -> tuple[int, int]:
+    valid_pattern = re.compile(r"^[a-z0-9_]+$")
+    total = 0
+    valid = 0
+    for dirpath, dirnames, _ in os.walk(root):
+        dirnames[:] = [
+            d for d in dirnames if not (d.startswith('.') or d.startswith('__'))
+        ]
+        for d in dirnames:
+            total += 1
+            if valid_pattern.match(d):
+                valid += 1
+    return valid, total
+
+
+def glossary_refs_kpi(root: Path) -> tuple[int, int]:
+    link_pattern = re.compile(r"\[[^\]]*\]\(([^)]+glossary[^)]*)\)")
+    total = 0
+    valid = 0
+    for path in root.rglob("*.md"):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except Exception:
+            continue
+        for match in link_pattern.finditer(text):
+            total += 1
+            target = match.group(1).split('#')[0]
+            if target.startswith("http://") or target.startswith("https://"):
+                continue
+            if (path.parent / target).resolve().exists():
+                valid += 1
+    return valid, total
+
+
+def main() -> None:
+    root = Path(__file__).resolve().parent.parent
+    percent_ok, ok_readmes, total_readmes = readme_kpi(root)
+    valid_dirs, total_dirs = directory_naming_kpi(root)
+    valid_refs, total_refs = glossary_refs_kpi(root)
+
+    print(f"README OK: {ok_readmes}/{total_readmes} ({percent_ok:.2f}%)")
+    print(f"Valid directory names: {valid_dirs}/{total_dirs}")
+    print(f"Glossary references updated: {valid_refs}/{total_refs}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- track consolidation metrics in a new report and Python script
- automate KPI reporting in GitHub Actions

## Testing
- `pytest`
- `python scripts/report_kpis.py`


------
https://chatgpt.com/codex/tasks/task_e_688e517bbc788329a832cec54ce0bbc2