### PR TITLE
chore: restrict Windows-only dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 psutil
 py-cpuinfo
 GPUtil
-wmi
-pywin32
+wmi; platform_system == "Windows"
+pywin32; platform_system == "Windows"


### PR DESCRIPTION
## Summary
- limit `wmi` and `pywin32` installation to Windows

## Testing
- `python -m pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e57921e7c8329a825afe7854c3275