### PR TITLE
Add glossary reference checker and update README terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,30 @@
 # AingZ_Platform_main — README v1
 
-> **STATUS:** `ACTUALIZADO`
-> **Última actualización:** 2025-08-02 | Autor: ChatGPT
+> **STATUS:** `UPDATED`
+> **Last update:** 2025-08-02 | Author: ChatGPT
 
 ---
 
-## 1. Resumen
-Bucket raíz que organiza los módulos principales de la plataforma.
+## 1. Summary
+Root bucket that organizes the platform's main modules.
 
-## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [BACKUP/](BACKUP/)
-- Enlaces a versiones relevantes o backups IA: [backup/](backup/)
+## 2. Backups / Context
+- Related backup folder: [BACKUP/](BACKUP/)
+- Links to relevant versions or AI backups: [backup/](backup/)
 
-## 3. Crossref y Mapping
-- **Referencia ascendente:** `[../]`
-- **Referencias laterales:** [./.git/], [./.pytest_cache/], [./BACKUP/], [./__pycache__/], [./apps/], [./backup/], [./connectors/], [./core/], [./infra/], [./legacy/], [./legacy_old/], [./log/], [./mig/], [./packages/], [./scripts/], [./tmp_staging/]
-- **Buckets destino típicos:** `[../DESTINO/]`
-- **Crossref central:** [Mapa Global](core/data/crossref_mapping_buckets_aingz_platform_v_1_20250731.md)
-- **Flujos/Pipelines relevantes:** [infra/pipelines/README.md](infra/pipelines/README.md)
+## 3. Cross‑references and Mapping
+- **Upward reference:** `[../]`
+- **Lateral references:** [./.git/], [./.pytest_cache/], [./BACKUP/], [./__pycache__/], [./apps/], [./backup/], [./connectors/], [./core/], [./infra/], [./legacy/], [./legacy_old/], [./log/], [./mig/], [./packages/], [./scripts/], [./tmp_staging/]
+- **Typical destination buckets:** `[../DESTINATION/]`
+- **Central crossref:** [Global Map](core/data/crossref_mapping_buckets_aingz_platform_v_1_20250731.md)
+- **Relevant pipelines:** [infra/pipelines/README.md](infra/pipelines/README.md)
 
-## 4. Precedencia en el Árbol de Directorios
+## 4. Directory Tree Precedence
 ```text
 AingZ_Platform_main/
 ```
 
-## 4.1 Procedencia en el Árbol de Directorios
+## 4.1 Directory Tree Origin
 ```text
 AingZ_Platform_main/
 ├── .git/
@@ -45,17 +45,22 @@ AingZ_Platform_main/
 └── tmp_staging/
 ```
 
-## 5. Pipeline y Workflows (Ciclo de Vida)
-Describe los pasos clave del ciclo de vida para los archivos de este bucket:
-1. **Ingreso / LEGACY o TMP:** [legacy/](legacy/) o [tmp_staging/](tmp_staging/)
+## 5. Pipeline and Workflows (Lifecycle)
+Describes key steps in the lifecycle for the files in this bucket:
+1. **Input / LEGACY or TMP:** [legacy/](legacy/) or [tmp_staging/](tmp_staging/)
 2. **Staging / MIG:** [mig/](mig/)
-3. **Consolidación / CORE:** [core/](core/)
-4. **Backup / Eliminación:** [backup/](backup/) y/o [BACKUP/](BACKUP/)
+3. **Consolidation / CORE:** [core/](core/)
+4. **Backup / Deletion:** [backup/](backup/) and/or [BACKUP/](BACKUP/)
 
-
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Adjust links according to the official pipeline and stages of `LEGACY→TMP→MIG→CORE→BACKUP`.
 
 ---
 
-Completar todos los campos con links activos una vez creada la estructura real.
+Fill all fields with active links once the real structure is created.
 
+## Terminology
+- [Bucket](core/kns/glossary/rw_b_glosario_code_v_2_20250729.md#buck-bucket)
+- [Pipeline](core/kns/glossary/rw_b_glosario_code_v_2_20250729.md#pipe-pipeline)
+- [Workflow](core/kns/glossary/rw_b_glosario_code_v_2_20250729.md#wf-workflow)
+- [Migration](core/kns/glossary/rw_b_glosario_code_v_2_20250729.md#mig-migration)
+- [Backup](core/kns/glossary/rw_b_glosario_code_v_2_20250729.md#bk-backup)

--- a/core/kns/glossary/rw_b_glosario_code_v_2_20250729.md
+++ b/core/kns/glossary/rw_b_glosario_code_v_2_20250729.md
@@ -39,7 +39,7 @@
 | B10 | STA | State | Estado (WIP, FINAL, ARCH). | Transversal | metadata.status |
 | B11 | ID  | Identifier | UID global. | Transversal | run.id |
 | B12 | TYP | Type | Extensión/formato. | Transversal | mime awareness |
-| B13 | BK  | Backup | Snapshot crítico. | Universal | archival storage |
+| B13 | BK  | <a id="bk-backup"></a>Backup | Snapshot crítico. | Universal | archival storage |
 | B14 | ACTV| ActiveAsset | Asset vivo/actual. | Transversal | live editor |
 | B15 | PURG| Purgatory | Directorio de obsoletos. | Transversal | cold storage |
 | B16 | DIFF| DiffAsset | Archivo de diferencias entre versiones. | Transversal | diff analysis |
@@ -64,7 +64,7 @@
 ## D. WORKFLOW & PIPELINES
 | ID | CODE | Name | Descripción | Relación | Features (OpenAI) |
 |----|------|------|-------------|----------|--------------------|
-| D01 | WF   | Workflow | Macro‑orquestación de procesos. | Raíz | run sequences |
+| D01 | WF   | <a id="wf-workflow"></a>Workflow | Macro‑orquestación de procesos. | Raíz | run sequences |
 | D02 | WF_M | WorkflowMacro | Orquesta múltiples WF. | Superior | orchestrator agent |
 | D03 | MPLN | MasterPlan | Blueprint estratégico global. | Hijo WF | plan generation |
 | D04 | PLN  | Plan | Cronograma específico. | Hijo MPLN | calendar tool |
@@ -77,7 +77,7 @@
 | D11 | VALD | Validation | Validación técnica. | Cierre WF | unit tests |
 | D12 | TMPLG| TemplateGenerator | Genera scaffolds/plantillas. | Secundario | assistants.tools.generate |
 | D13 | TUNG | Tuning | Ajuste iterativo de parámetros. | Secundario | hyper‑param search |
-| D14 | MIG  | Migration | Migración legacy→nuevo. | Hijo WF | data migration tool |
+| D14 | MIG  | <a id="mig-migration"></a>Migration | Migración legacy→nuevo. | Hijo WF | data migration tool |
 | D15 | MAP  | Mapping | Mapeo de correspondencias. | Sec MIG | mapping table |
 | D16 | CLSS | Classification | Taxonomía automática. | Sec MAP | classification models |
 | D17 | FBCK | FeedbackEval | Evaluación estructurada de feedback. | Herm REVP | evals API |
@@ -157,6 +157,12 @@
 | I09 | BRAIN | Brainstorm | Baseline brainstorming. | ideation tool |
 | I10 | IDEA | IdeaDraft | Draft incremental de ideas. | ideation tool |
 | I11 | KNX | KnowledgeExtract | Extracto de conocimiento aplicado. | vector extract |
+
+## J. REPO STRUCTURE
+| ID | CODE | Name | Descripción | Features (OpenAI) |
+|----|------|------|-------------|-------------------|
+| J01 | BUCK | <a id="buck-bucket"></a>Bucket | Contenedor lógico que agrupa módulos y datos. | storage buckets |
+| J02 | PIPE | <a id="pipe-pipeline"></a>Pipeline | Flujo secuencial de procesamiento de datos. | pipeline orchestration |
 
 ---
 

--- a/scripts/check_glossary_refs.py
+++ b/scripts/check_glossary_refs.py
@@ -1,0 +1,58 @@
+"""Validate that technical terms listed in README files exist in the glossary."""
+import re
+import sys
+from pathlib import Path
+
+def load_glossary_terms(glossary_path: Path) -> set[str]:
+    terms: set[str] = set()
+    pattern = re.compile(r"^\|\s*[A-Z0-9_]+\s*\|\s*[A-Z0-9_]+\s*\|\s*(.+?)\s*\|", re.UNICODE)
+    with glossary_path.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            if line.startswith("|"):
+                match = pattern.match(line)
+                if match:
+                    name_cell = re.sub(r"<[^>]+>", "", match.group(1)).strip()
+                    if name_cell:
+                        terms.add(name_cell.lower())
+    return terms
+
+def readme_terms(readme_path: Path) -> list[str]:
+    content = readme_path.read_text(encoding="utf-8")
+    m = re.search(r"##+\s*Terminology\n(.+?)(\n##|\Z)", content, re.DOTALL | re.IGNORECASE)
+    if not m:
+        return []
+    section = m.group(1)
+    terms: list[str] = []
+    for line in section.splitlines():
+        line = line.strip()
+        if line.startswith("-"):
+            term_match = re.match(r"-\s*(?:\[([^\]]+)\]|([^\[]+))", line)
+            if term_match:
+                term = term_match.group(1) or term_match.group(2)
+                term = term.strip().lower()
+                term = re.sub(r"[^a-z0-9]+", " ", term).strip()
+                if term:
+                    terms.append(term)
+    return terms
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parent.parent
+    glossary = repo_root / "core/kns/glossary/rw_b_glosario_code_v_2_20250729.md"
+    known_terms = load_glossary_terms(glossary)
+    failures: list[str] = []
+    for readme in repo_root.rglob("README.md"):
+        terms = readme_terms(readme)
+        if not terms:
+            continue
+        missing = [t for t in terms if t not in known_terms]
+        if missing:
+            failures.append(f"{readme}: missing terms: {', '.join(missing)}")
+    if failures:
+        for msg in failures:
+            print(msg)
+        return 1
+    print("All glossary references are valid.")
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- translate root README to English and add Terminology section linking glossary terms
- extend glossary with Bucket and Pipeline entries and anchors for existing terms
- add script to validate that README terminology is defined in the glossary

## Testing
- `python scripts/check_glossary_refs.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e5b64cf388329a8ed8243066f1dfa