### PR TITLE
refactor: replace BACKUP with bk_temp

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@
 Root bucket that organizes the platform's main modules.
 
 ## 2. Backups / Context
-- Related backup folder: [BACKUP/](BACKUP/)
+- Related backup folder: [bk_temp/](bk_temp/)
 - Links to relevant versions or AI backups: [backup/](backup/)
 
 ## 3. Cross‑references and Mapping
 - **Upward reference:** `[../]`
-- **Lateral references:** [./.git/], [./.pytest_cache/], [./BACKUP/], [./__pycache__/], [./apps/], [./backup/], [./connectors/], [./core/], [./infra/], [./legacy/], [./legacy_old/], [./log/], [./mig/], [./packages/], [./scripts/], [./tmp_staging/]
+- **Lateral references:** [./.git/], [./.pytest_cache/], [./bk_temp/], [./__pycache__/], [./apps/], [./backup/], [./connectors/], [./core/], [./infra/], [./legacy/], [./legacy_old/], [./log/], [./mig/], [./packages/], [./scripts/], [./tmp_staging/]
 - **Typical destination buckets:** `[../DESTINATION/]`
 - **Central crossref:** [Global Map](core/data/crossref_mapping_buckets_aingz_platform_v_1_20250731.md)
 - **Relevant pipelines:** [infra/pipelines/README.md](infra/pipelines/README.md)
@@ -29,7 +29,7 @@ AingZ_Platform_main/
 AingZ_Platform_main/
 ├── .git/
 ├── .pytest_cache/
-├── BACKUP/
+├── bk_temp/
 ├── __pycache__/
 ├── apps/
 ├── backup/
@@ -50,9 +50,9 @@ Describes key steps in the lifecycle for the files in this bucket:
 1. **Input / LEGACY or TMP:** [legacy/](legacy/) or [tmp_staging/](tmp_staging/)
 2. **Staging / MIG:** [mig/](mig/)
 3. **Consolidation / CORE:** [core/](core/)
-4. **Backup / Deletion:** [backup/](backup/) and/or [BACKUP/](BACKUP/)
+4. **bk_temp / Deletion:** [backup/](backup/) and/or [bk_temp/](bk_temp/)
 
-Adjust links according to the official pipeline and stages of `LEGACY→TMP→MIG→CORE→BACKUP`.
+Adjust links according to the official pipeline and stages of `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/apps/README.md
+++ b/apps/README.md
@@ -9,12 +9,12 @@
 Componentes y servicios de aplicaciones de la plataforma.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../BACKUP/](../BACKUP/)
+- Carpeta de snapshots relacionada: [../bk_temp/](../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../backup/](../backup/)
 
 ## 3. Crossref y Mapping
 - **Referencia ascendente:** `[../]`
-- **Referencias laterales:** [../.git/], [../.pytest_cache/], [../BACKUP/], [../__pycache__/], [../backup/], [../connectors/], [../core/], [../infra/], [../legacy/], [../legacy_old/], [../log/], [../mig/], [../packages/], [../scripts/], [../tmp_staging/]
+- **Referencias laterales:** [../.git/], [../.pytest_cache/], [../bk_temp/], [../__pycache__/], [../backup/], [../connectors/], [../core/], [../infra/], [../legacy/], [../legacy_old/], [../log/], [../mig/], [../packages/], [../scripts/], [../tmp_staging/]
 - **Buckets destino típicos:** `[../DESTINO/]`
 - **Crossref central:** [Mapa Global](../core/data/crossref_mapping_buckets_aingz_platform_v_1_20250731.md)
 - **Flujos/Pipelines relevantes:** [../infra/pipelines/README.md](../infra/pipelines/README.md)
@@ -36,9 +36,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../legacy/](../legacy/) o [../tmp_staging/](../tmp_staging/)
 2. **Staging / MIG:** [../mig/](../mig/)
 3. **Consolidación / CORE:** [../core/](../core/)
-4. **Backup / Eliminación:** [../backup/](../backup/) y/o [../BACKUP/](../BACKUP/)
+4. **bk_temp / Eliminación:** [../backup/](../backup/) y/o [../bk_temp/](../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/backup/README.md
+++ b/backup/README.md
@@ -10,12 +10,12 @@
 Espacio de respaldo temporal previo a consolidación.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../BACKUP/](../BACKUP/)
+- Carpeta de snapshots relacionada: [../bk_temp/](../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [./](./)
 
 ## 3. Crossref y Mapping
 - **Referencia ascendente:** `[../]`
-- **Referencias laterales:** [../.git/], [../.pytest_cache/], [../BACKUP/], [../__pycache__/], [../apps/], [../connectors/], [../core/], [../infra/], [../legacy/], [../legacy_old/], [../log/], [../mig/], [../packages/], [../scripts/], [../tmp_staging/]
+- **Referencias laterales:** [../.git/], [../.pytest_cache/], [../bk_temp/], [../__pycache__/], [../apps/], [../connectors/], [../core/], [../infra/], [../legacy/], [../legacy_old/], [../log/], [../mig/], [../packages/], [../scripts/], [../tmp_staging/]
 - **Buckets destino típicos:** `[../DESTINO/]`
 - **Crossref central:** [Mapa Global](../core/data/crossref_mapping_buckets_aingz_platform_v_1_20250731.md)
 - **Flujos/Pipelines relevantes:** [../infra/pipelines/README.md](../infra/pipelines/README.md)
@@ -40,15 +40,14 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../legacy/](../legacy/) o [../tmp_staging/](../tmp_staging/)
 2. **Staging / MIG:** [../mig/](../mig/)
 3. **Consolidación / CORE:** [../core/](../core/)
-4. **Backup / Eliminación:** [./](./) y/o [../BACKUP/](../BACKUP/)
+4. **bk_temp / Eliminación:** [./](./) y/o [../bk_temp/](../bk_temp/)
 
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ## 6. Etapas previas y finales
 - [CORE](../core/)
-- [backup](./)
-- [BACKUP final](../BACKUP/)
+- [bk_temp](../bk_temp/)
 
 ---
 

--- a/backup/ai/README.md
+++ b/backup/ai/README.md
@@ -10,7 +10,7 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../BACKUP/](../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../bk_temp/](../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../](../)
 
 
@@ -39,7 +39,7 @@ ai/
 1. **Ingreso / LEGACY o TMP:** [../../legacy/](../../legacy/) o [../../tmp_staging/](../../tmp_staging/)
 2. **Staging / MIG:** [../../mig/](../../mig/)
 3. **Consolidación / CORE:** [../../core/](../../core/)
-4. **Backup / Eliminación:** [../](../) y/o [../../BACKUP/](../../BACKUP/)
+4. **bk_temp / Eliminación:** [../](../) y/o [../../bk_temp/](../../bk_temp/)
 
 
 ---

--- a/backup/ext/README.md
+++ b/backup/ext/README.md
@@ -10,7 +10,7 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../BACKUP/](../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../bk_temp/](../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../](../)
 
 
@@ -40,10 +40,10 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../../legacy/](../../legacy/) o [../../tmp_staging/](../../tmp_staging/)
 2. **Staging / MIG:** [../../mig/](../../mig/)
 3. **Consolidación / CORE:** [../../core/](../../core/)
-4. **Backup / Eliminación:** [../](../) y/o [../../BACKUP/](../../BACKUP/)
+4. **bk_temp / Eliminación:** [../](../) y/o [../../bk_temp/](../../bk_temp/)
 
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/backup/int/README.md
+++ b/backup/int/README.md
@@ -10,7 +10,7 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../BACKUP/](../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../bk_temp/](../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../](../)
 
 
@@ -40,10 +40,10 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../../legacy/](../../legacy/) o [../../tmp_staging/](../../tmp_staging/)
 2. **Staging / MIG:** [../../mig/](../../mig/)
 3. **Consolidación / CORE:** [../../core/](../../core/)
-4. **Backup / Eliminación:** [../](../) y/o [../../BACKUP/](../../BACKUP/)
+4. **bk_temp / Eliminación:** [../](../) y/o [../../bk_temp/](../../bk_temp/)
 
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/bk_temp/.gitignore
+++ b/bk_temp/.gitignore
@@ -1,0 +1,6 @@
+*
+!.gitignore
+!README.md
+!ai/
+!ext/
+!int/

--- a/bk_temp/README.md
+++ b/bk_temp/README.md
@@ -1,4 +1,4 @@
-# backup — README v1
+# bk_temp — README v1
 
 > **STATUS:** `ACTUALIZADO`
 > **Última actualización:** 2025-08-02 | Autor: ChatGPT
@@ -7,15 +7,15 @@
 ---
 
 ## 1. Resumen
-Espacio de respaldo temporal previo a consolidación.
+Espacio temporal para respaldos antes de moverlos a almacenamiento externo.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../BACKUP/](../BACKUP/)
+- Carpeta de snapshots relacionada: [../bk_temp/](../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [./](./)
 
 ## 3. Crossref y Mapping
 - **Referencia ascendente:** `[../]`
-- **Referencias laterales:** [../.git/], [../.pytest_cache/], [../BACKUP/], [../__pycache__/], [../apps/], [../connectors/], [../core/], [../infra/], [../legacy/], [../legacy_old/], [../log/], [../mig/], [../packages/], [../scripts/], [../tmp_staging/]
+- **Referencias laterales:** [../.git/], [../.pytest_cache/], [../bk_temp/], [../__pycache__/], [../apps/], [../connectors/], [../core/], [../infra/], [../legacy/], [../legacy_old/], [../log/], [../mig/], [../packages/], [../scripts/], [../tmp_staging/]
 - **Buckets destino típicos:** `[../DESTINO/]`
 - **Crossref central:** [Mapa Global](../core/data/crossref_mapping_buckets_aingz_platform_v_1_20250731.md)
 - **Flujos/Pipelines relevantes:** [../infra/pipelines/README.md](../infra/pipelines/README.md)
@@ -24,12 +24,12 @@ Espacio de respaldo temporal previo a consolidación.
 ## 4. Precedencia en el Árbol de Directorios
 ```text
 AingZ_Platform_main/
-└── backup/
+└── bk_temp/
 ```
 
 ## 4.1 Procedencia en el Árbol de Directorios
 ```text
-backup/
+bk_temp/
 ├── ai/
 ├── ext/
 └── int/
@@ -40,15 +40,14 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../legacy/](../legacy/) o [../tmp_staging/](../tmp_staging/)
 2. **Staging / MIG:** [../mig/](../mig/)
 3. **Consolidación / CORE:** [../core/](../core/)
-4. **Backup / Eliminación:** [./](./) y/o [../BACKUP/](../BACKUP/)
+4. **bk_temp / Eliminación:** [./](./) y/o [../bk_temp/](../bk_temp/)
 
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ## 6. Etapas previas y finales
 - [CORE](../core/)
-- [backup](./)
-- [BACKUP final](../BACKUP/)
+- [bk_temp](./)
 
 ---
 

--- a/bk_temp/ai/.gitignore
+++ b/bk_temp/ai/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!README.md

--- a/bk_temp/ai/README.md
+++ b/bk_temp/ai/README.md
@@ -1,4 +1,4 @@
-# int — README v1
+# bk_temp/ai — README v1
 
 > **STATUS:** `ACTUALIZADO`
 > **Última actualización:** 2025-08-02 | Autor: ChatGPT
@@ -10,14 +10,14 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../BACKUP/](../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../bk_temp/](../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../](../)
 
 
 ## 3. Crossref y Mapping
 - **Referencia ascendente:** `[../]`
-- **Referencias laterales:** [../ai/], [../ext/]
-- **Buckets destino típicos:** `[../DESTINO/]`
+- **Referencias laterales:** [../ext/], [../int/]
+- **Buckets destino típicos:** `[../../PURGATORIO/ai/]`, `[../../CORE/]`
 - **Crossref central:** [Mapa Global](../../core/data/crossref_mapping_buckets_aingz_platform_v_1_20250731.md)
 - **Flujos/Pipelines relevantes:** [../../infra/pipelines/README.md](../../infra/pipelines/README.md)
 
@@ -25,27 +25,23 @@ Descripción pendiente.
 ## 4. Precedencia en el Árbol de Directorios
 ```text
 AingZ_Platform_main/
-└── backup/
-    └── int/
+└── bk_temp/
+    └── ai/
 ```
 
 ## 4.1 Procedencia en el Árbol de Directorios
 ```text
-int/
+ai/
 └── (sin subdirectorios)
 ```
 
 ## 5. Pipeline y Workflows (Ciclo de Vida)
-Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../../legacy/](../../legacy/) o [../../tmp_staging/](../../tmp_staging/)
 2. **Staging / MIG:** [../../mig/](../../mig/)
 3. **Consolidación / CORE:** [../../core/](../../core/)
-4. **Backup / Eliminación:** [../](../) y/o [../../BACKUP/](../../BACKUP/)
+4. **bk_temp / Eliminación:** [../](../) y/o [../../bk_temp/](../../bk_temp/)
 
-
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
 
 ---
-
 Completar todos los campos con links activos una vez creada la estructura real.
 

--- a/bk_temp/ext/.gitignore
+++ b/bk_temp/ext/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!README.md

--- a/bk_temp/ext/README.md
+++ b/bk_temp/ext/README.md
@@ -10,7 +10,7 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../BACKUP/](../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../bk_temp/](../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../](../)
 
 
@@ -25,7 +25,7 @@ Descripción pendiente.
 ## 4. Precedencia en el Árbol de Directorios
 ```text
 AingZ_Platform_main/
-└── backup/
+└── bk_temp/
     └── ext/
 ```
 
@@ -40,10 +40,10 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../../legacy/](../../legacy/) o [../../tmp_staging/](../../tmp_staging/)
 2. **Staging / MIG:** [../../mig/](../../mig/)
 3. **Consolidación / CORE:** [../../core/](../../core/)
-4. **Backup / Eliminación:** [../](../) y/o [../../BACKUP/](../../BACKUP/)
+4. **bk_temp / Eliminación:** [../](../) y/o [../../bk_temp/](../../bk_temp/)
 
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/bk_temp/int/.gitignore
+++ b/bk_temp/int/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!README.md

--- a/bk_temp/int/README.md
+++ b/bk_temp/int/README.md
@@ -1,4 +1,4 @@
-# backup/ai — README v1
+# int — README v1
 
 > **STATUS:** `ACTUALIZADO`
 > **Última actualización:** 2025-08-02 | Autor: ChatGPT
@@ -10,14 +10,14 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../BACKUP/](../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../bk_temp/](../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../](../)
 
 
 ## 3. Crossref y Mapping
 - **Referencia ascendente:** `[../]`
-- **Referencias laterales:** [../ext/], [../int/]
-- **Buckets destino típicos:** `[../../PURGATORIO/ai/]`, `[../../CORE/]`
+- **Referencias laterales:** [../ai/], [../ext/]
+- **Buckets destino típicos:** `[../DESTINO/]`
 - **Crossref central:** [Mapa Global](../../core/data/crossref_mapping_buckets_aingz_platform_v_1_20250731.md)
 - **Flujos/Pipelines relevantes:** [../../infra/pipelines/README.md](../../infra/pipelines/README.md)
 
@@ -25,23 +25,27 @@ Descripción pendiente.
 ## 4. Precedencia en el Árbol de Directorios
 ```text
 AingZ_Platform_main/
-└── backup/
-    └── ai/
+└── bk_temp/
+    └── int/
 ```
 
 ## 4.1 Procedencia en el Árbol de Directorios
 ```text
-ai/
+int/
 └── (sin subdirectorios)
 ```
 
 ## 5. Pipeline y Workflows (Ciclo de Vida)
+Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../../legacy/](../../legacy/) o [../../tmp_staging/](../../tmp_staging/)
 2. **Staging / MIG:** [../../mig/](../../mig/)
 3. **Consolidación / CORE:** [../../core/](../../core/)
-4. **Backup / Eliminación:** [../](../) y/o [../../BACKUP/](../../BACKUP/)
+4. **bk_temp / Eliminación:** [../](../) y/o [../../bk_temp/](../../bk_temp/)
 
+
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
+
 Completar todos los campos con links activos una vez creada la estructura real.
 

--- a/connectors/README.md
+++ b/connectors/README.md
@@ -9,12 +9,12 @@
 Integraciones y conectores con sistemas externos.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../BACKUP/](../BACKUP/)
+- Carpeta de snapshots relacionada: [../bk_temp/](../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../backup/](../backup/)
 
 ## 3. Crossref y Mapping
 - **Referencia ascendente:** `[../]`
-- **Referencias laterales:** [../.git/], [../.pytest_cache/], [../BACKUP/], [../__pycache__/], [../apps/], [../backup/], [../core/], [../infra/], [../legacy/], [../legacy_old/], [../log/], [../mig/], [../packages/], [../scripts/], [../tmp_staging/]
+- **Referencias laterales:** [../.git/], [../.pytest_cache/], [../bk_temp/], [../__pycache__/], [../apps/], [../backup/], [../core/], [../infra/], [../legacy/], [../legacy_old/], [../log/], [../mig/], [../packages/], [../scripts/], [../tmp_staging/]
 - **Buckets destino típicos:** `[../DESTINO/]`
 - **Crossref central:** [Mapa Global](../core/data/crossref_mapping_buckets_aingz_platform_v_1_20250731.md)
 - **Flujos/Pipelines relevantes:** [../infra/pipelines/README.md](../infra/pipelines/README.md)
@@ -36,9 +36,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../legacy/](../legacy/) o [../tmp_staging/](../tmp_staging/)
 2. **Staging / MIG:** [../mig/](../mig/)
 3. **Consolidación / CORE:** [../core/](../core/)
-4. **Backup / Eliminación:** [../backup/](../backup/) y/o [../BACKUP/](../BACKUP/)
+4. **bk_temp / Eliminación:** [../backup/](../backup/) y/o [../bk_temp/](../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/core/README.md
+++ b/core/README.md
@@ -9,12 +9,12 @@
 Almacén consolidado de datos y recursos centrales.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../BACKUP/](../BACKUP/)
+- Carpeta de snapshots relacionada: [../bk_temp/](../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../backup/](../backup/)
 
 ## 3. Crossref y Mapping
 - **Referencia ascendente:** `[../]`
-- **Referencias laterales:** [../.git/], [../.pytest_cache/], [../BACKUP/], [../__pycache__/], [../apps/], [../backup/], [../connectors/], [../infra/], [../legacy/], [../legacy_old/], [../log/], [../mig/], [../packages/], [../scripts/], [../tmp_staging/]
+- **Referencias laterales:** [../.git/], [../.pytest_cache/], [../bk_temp/], [../__pycache__/], [../apps/], [../backup/], [../connectors/], [../infra/], [../legacy/], [../legacy_old/], [../log/], [../mig/], [../packages/], [../scripts/], [../tmp_staging/]
 - **Buckets destino típicos:** `[../DESTINO/]`
 - **Crossref central:** [Mapa Global](data/crossref_mapping_buckets_aingz_platform_v_1_20250731.md)
 - **Flujos/Pipelines relevantes:** [../infra/pipelines/README.md](../infra/pipelines/README.md)
@@ -41,9 +41,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../legacy/](../legacy/) o [../tmp_staging/](../tmp_staging/)
 2. **Staging / MIG:** [../mig/](../mig/)
 3. **Consolidación / CORE:** [./](./)
-4. **Backup / Eliminación:** [../backup/](../backup/) y/o [../BACKUP/](../BACKUP/)
+4. **bk_temp / Eliminación:** [../backup/](../backup/) y/o [../bk_temp/](../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ### Enlaces directos a cada etapa del ciclo
 
@@ -51,7 +51,7 @@ Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG�
 - [TMP_STAGING](../tmp_staging/)
 - [MIG](../mig/)
 - [CORE](./)
-- [backup](../backup/) / [BACKUP final](../BACKUP/)
+- [backup](../backup/) / [bk_temp final](../bk_temp/)
 
 ---
 

--- a/core/data/README.md
+++ b/core/data/README.md
@@ -9,7 +9,7 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../BACKUP/](../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../bk_temp/](../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../../backup/](../../backup/)
 
 ## 3. Crossref y Mapping
@@ -40,9 +40,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../../legacy/](../../legacy/) o [../../tmp_staging/](../../tmp_staging/)
 2. **Staging / MIG:** [../../mig/](../../mig/)
 3. **Consolidación / CORE:** [../](../)
-4. **Backup / Eliminación:** [../../backup/](../../backup/) y/o [../../BACKUP/](../../BACKUP/)
+4. **bk_temp / Eliminación:** [../../backup/](../../backup/) y/o [../../bk_temp/](../../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/core/data/blueprint_aingz_platform_v_1_20250731.md
+++ b/core/data/blueprint_aingz_platform_v_1_20250731.md
@@ -18,7 +18,7 @@
 - **Ruleset:** Extiende RAW BASE RwB, ahora como “AingZ\_Platform Ruleset” (RWB+).
   - **Literalidad, trazabilidad y chunking máximo.**
   - **Naming universal**: SRC·STG·ROLE siempre obligatorio, mapeo a Matrix y glosario CODE.
-  - **Ciclo de vida estricto**: LEGACY→STAGING→CORE→BACKUP/ELIMINACIÓN, sin residuos ni referencias grises.
+  - **Ciclo de vida estricto**: LEGACY→STAGING→CORE→bk_temp/ELIMINACIÓN, sin residuos ni referencias grises.
   - **Integración IA ready**: toda estructura preparada para chunking, feedback, snapshot y automatización IA.
   - **Control de conectores/apps:** cada integración documentada con reglas, scripts, templates, tokens y buenas prácticas.
   - **Seguridad y compliance:** versionado, backups, control de acceso y logs de auditoría globales.
@@ -44,7 +44,7 @@ AingZ_Platform/
 ├── DATA/                      # Matrices, datasets, mappings, versus
 ├── LOG/                       # Logs, changelogs, bitácoras
 │   └── AUDT/                  # Audit logs pesados
-├── BACKUP/                    # Snapshots/Backups (INT/EXT_COM/EXT_OFF/AI)
+├── bk_temp/                    # Snapshots/Backups (INT/EXT_COM/EXT_OFF/AI)
 │   ├── INT/                   # Backups internos
 │   ├── EXT_OFF/               # Backups externos oficiales
 │   ├── EXT_COM/               # Backups comunidad externa

--- a/core/data/crossref_mapping_buckets_aingz_platform_v_1_20250731.md
+++ b/core/data/crossref_mapping_buckets_aingz_platform_v_1_20250731.md
@@ -20,9 +20,9 @@
 | --------------- | --------------------- | ----------------------- | ----------------------- | --------------- |
 | LEGACY/         | Ingreso manual/auto   | TMP/, MIG/              | TMP/, MIG/              | Sí              |
 | TMP/            | LEGACY/, scripts dev  | MIG/, CORE/             | MIG/, CORE/             | Sí              |
-| MIG/            | LEGACY/, TMP/         | CORE/, BACKUP/          | CORE/, BACKUP/          | Sí              |
-| CORE/           | MIG/                  | BACKUP/, LOG/           | BACKUP/                 | Sí              |
-| BACKUP/         | CORE/, MIG/           | -                       | -                       | Sí              |
+| MIG/            | LEGACY/, TMP/         | CORE/, bk_temp/          | CORE/, bk_temp/          | Sí              |
+| CORE/           | MIG/                  | bk_temp/, LOG/           | bk_temp/                 | Sí              |
+| bk_temp/         | CORE/, MIG/           | -                       | -                       | Sí              |
 | LOG/            | Todos                 | AUDT/, KNS/LEARN/       | -                       | Sí              |
 | KNS/            | Todos (insights)      | LEARN/                  | -                       | Sí              |
 | DATA/           | CORE/, TMP/, MIG/     | -                       | -                       | Sí              |
@@ -67,8 +67,8 @@ flowchart TD
     LEGACY --> TMP
     TMP --> MIG
     MIG --> CORE
-    CORE --> BACKUP
-    MIG --> BACKUP
+    CORE --> bk_temp
+    MIG --> bk_temp
     ALL --> LOG
     ALL --> KNS
 ```
@@ -89,7 +89,7 @@ from pathlib import Path
 
 BUCKETS = [
     'packages', 'WF', 'DOC', 'KNS', 'KNS/LEARN', 'SCR', 'DATA', 'LOG', 'LOG/AUDT',
-    'BACKUP', 'BACKUP/int', 'BACKUP/ext', 'BACKUP/ai', 'LEGACY', 'TMP', 'MIG', 'CORE',
+    'bk_temp', 'bk_temp/int', 'bk_temp/ext', 'bk_temp/ai', 'LEGACY', 'TMP', 'MIG', 'CORE',
     'CONNECTORS', 'APPS', 'PIPELINES', 'SNAPSHOTS_CTX', 'SNAPSHOTS_CTX/o3',
     'SNAPSHOTS_CTX/gpt4', 'SNAPSHOTS_CTX/turbo', 'SNAPSHOTS_CTX/custom', 'INFRA'
 ]

--- a/core/data/ctx_o_3_rw_b_total_20250731.md
+++ b/core/data/ctx_o_3_rw_b_total_20250731.md
@@ -14,9 +14,9 @@
 
 ## 2. PRINCIPIOS Y REGLAS BASE
 
-- Arquitectura Monorepo Modular: cada package independiente, buckets y recursos compartidos (`WF/`, `DOC/`, `KNS/`, `SCR/`, `DATA/`, `LOG/`, `BACKUP/`, `TMP/`, `MIG/`).
+- Arquitectura Monorepo Modular: cada package independiente, buckets y recursos compartidos (`WF/`, `DOC/`, `KNS/`, `SCR/`, `DATA/`, `LOG/`, `bk_temp/`, `TMP/`, `MIG/`).
 - Naming obligatorio `SRC·STG·ROLE` (ver Matrix y glosario).
-- Flujos: LEGACY→STAGING→ACTIVO/CORE→BACKUP/ELIMINACIÓN.
+- Flujos: LEGACY→STAGING→ACTIVO/CORE→bk_temp/ELIMINACIÓN.
 - Prohibido citar legacy en activos, consolidar y eliminar residuos tras merge.
 - Workflows y scripts siempre alineados a arquitectura y límites de tokens IA.
 
@@ -41,7 +41,7 @@ Repo Root /
 ├── DATA/                     # Matrices y datasets
 ├── LOG/                      # Logs y changelogs
 │   └── AUDT/                 # Audit logs pesados
-├── BACKUP/                   # Snapshots/Backups (INT/EXT_COM/EXT_OFF/AI)
+├── bk_temp/                   # Snapshots/Backups (INT/EXT_COM/EXT_OFF/AI)
 ├── PURGATORIO/               # Staging de legacy, obsoletos
 │   ├── LEGACY/               # Zona exclusiva de activos antiguos/externos
 │   └── AI/                   # Purgatorio IA (Matrix)
@@ -65,12 +65,12 @@ Repo Root /
 2. **Auditoría y procesamiento:** En STAGING/TMP según workflow, naming provisional.
 3. **Validación QA:** Checklist, feedback, triggers (ver diccionario y glosario).
 4. **Consolidación:** Movimiento a CORE/ASSETS/KNS/ según naturaleza y rol.
-5. **Backup/Eliminación:** Snapshots en BACKUP si aplica, eliminación física tras merge.
+5. **Backup/Eliminación:** Snapshots en bk_temp si aplica, eliminación física tras merge.
 
 - **LEGACY:** zona cuarentena, todo archivo pendiente, sólo usable tras migración y QA.
 - **STAGING:** todo asset en revisión, testing o feedback, prohibido mover a activos sin cumplir QA y naming RwB.
 - **CORE/ASSETS/KNS:** solo activos validados, versionados y referenciados.
-- **BACKUP:** compresión solo para externos o por requerimiento legal.
+- **bk_temp:** compresión solo para externos o por requerimiento legal.
 
 ---
 
@@ -125,7 +125,7 @@ Repo Root /
 ## 11. NOTAS Y CHECKLIST DE COBERTURA (BARRIDO\_LITERAL)
 
 - ¿Blueprint, Matrix y Glosario referenciados y actualizados?
-- ¿Flujo de LEGACY→STAGING→ACTIVO/CORE→BACKUP/ELIMINACIÓN operativo y sin residuos?
+- ¿Flujo de LEGACY→STAGING→ACTIVO/CORE→bk_temp/ELIMINACIÓN operativo y sin residuos?
 - ¿Naming universal y triggers integrados?
 - ¿Snapshots y contextos curados bajo límite tokens?
 - ¿Workflows y logs actualizados y trazables?

--- a/core/data/mplan/README.md
+++ b/core/data/mplan/README.md
@@ -9,7 +9,7 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../../BACKUP/](../../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../../bk_temp/](../../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../../../backup/](../../../backup/)
 
 ## 3. Crossref y Mapping
@@ -38,9 +38,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../../../legacy/](../../../legacy/) o [../../../tmp_staging/](../../../tmp_staging/)
 2. **Staging / MIG:** [../../../mig/](../../../mig/)
 3. **Consolidación / CORE:** [../../](../../)
-4. **Backup / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../BACKUP/](../../../BACKUP/)
+4. **bk_temp / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../bk_temp/](../../../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/core/data/mplan/o3_full_instructions.md
+++ b/core/data/mplan/o3_full_instructions.md
@@ -34,7 +34,7 @@ This document consolidates important instructions, context, and file snapshots f
 ├── SCR/
 ├── DATA/
 ├── LOG/
-├── BACKUP/
+├── bk_temp/
 ├── PURGATORIO/
 ├── TMP/
 └── MIG/
@@ -283,7 +283,7 @@ Repo Root /
 ├── DATA/                  # Matrices, datasets, CSV/Parquet
 ├── LOG/                   # Logs, changelogs, bitácoras (E01)
 │   └── AUDT/              # Audit logs pesados (E06)
-├── BACKUP/                # Snapshots y BLN (B13)
+├── bk_temp/                # Snapshots y BLN (B13)
 ├── PURGATORIO/            # Obsoletos/legacy (B15)
 │   └── LEGACY/            # Activos antiguos/externos para migración
 ├── TMP/                   # Temp files, scratchpads, procesamiento previo consolidación
@@ -306,7 +306,7 @@ Repo Root /
 | R08 | `/DATA`              | CORE      | MTR       | Matrices, datasets, CSV/Parquet.                                            | H01             |
 | R09 | `/LOG`               | CORE      | LOG       | Logs, changelogs, bitácoras.                                                | E01             |
 | R10 | `/LOG/AUDT`          | AU        | ADT       | Audit logs detallados (pesados).                                            | E06             |
-| R11 | `/BACKUP`            | BK        | BK        | Snapshots BLN y backups comprimidos.                                        | B13             |
+| R11 | `/bk_temp`            | BK        | BK        | Snapshots BLN y backups comprimidos.                                        | B13             |
 | R12 | `/PURGATORIO`        | PG        | PURG      | Stage de obsoletos antes de eliminación o migración legacy.                 | B15             |
 | R13 | `/PURGATORIO/LEGACY` | LG        | LEGACY    | Activos antiguos/externos para migración.                                   | LEGACY          |
 | R14 | `/TMP`               | TEMP      | TMP       | Archivos temporales y scratchpad de dictado/auditoría.                      | TMP             |
@@ -343,7 +343,7 @@ Repo Root /
 3. Consolidado/manual mapping → `/DOC` o `/KNS`
 4. Migración literal → `/MIG`
 5. Auditoría final → `/LOG/AUDT`
-6. Si se archiva, pasa a `/PURGATORIO` o `/BACKUP`
+6. Si se archiva, pasa a `/PURGATORIO` o `/bk_temp`
 
 ---
 
@@ -422,7 +422,7 @@ Repo Root /
 | B17 | TRG_AUDIT_TL | TriggerAuditTL | Disparador auditoría TL | Ciclo TL | event hooks |
 | B18 | TRG_CONSOLIDATE_TL | TriggerConsolidateTL | Disparador consolidación TL | Ciclo TL | event hooks |
 | B19 | TRG_AUDIT_EXT_OFF | TriggerAuditExternalOfficial | Disparador auditoría de assets externos oficiales | Ciclo EXT | event hooks |
-| B20 | TRG_AUDIT_BACKUP | TriggerAuditBackup | Disparador auditoría de respaldos | Ciclo BK | event hooks |
+| B20 | TRG_AUDIT_bk_temp | TriggerAuditBackup | Disparador auditoría de respaldos | Ciclo BK | event hooks |
 | B21 | TRG_TRAIN_EXT_COM | TriggerTrainExternalCommunity | Disparador training assets comunidad externa | Ciclo TL | event hooks |
 | B22 | TRG_AUDIT_LEGACY | TriggerAuditLegacy | Disparador auditoría de archivos legacy | Ciclo LEG | event hooks |
 | B23 | TRG_PURGE_AI | TriggerPurgeAI | Disparador purga de datos IA | Ciclo AI | event hooks |
@@ -572,7 +572,7 @@ Repo Root /
 | B17 | TRG_AUDIT_TL | TriggerAuditTL | "🔔 TRG_AUDIT_TL" | Trigger | MD | audit_tl.md |
 | B18 | TRG_CONSOLIDATE_TL | TriggerConsolidateTL | "🔔 TRG_CONSOLIDATE_TL" | Trigger | MD | consolidate_tl.md |
 | B19 | TRG_AUDIT_EXT_OFF | TriggerAuditExternalOfficial | "🔔 TRG_AUDIT_EXT_OFF" | Trigger | MD | audit_ext_off.md |
-| B20 | TRG_AUDIT_BACKUP | TriggerAuditBackup | "🔔 TRG_AUDIT_BACKUP" | Trigger | MD | audit_backup.md |
+| B20 | TRG_AUDIT_bk_temp | TriggerAuditBackup | "🔔 TRG_AUDIT_bk_temp" | Trigger | MD | audit_backup.md |
 | B21 | TRG_TRAIN_EXT_COM | TriggerTrainExternalCommunity | "🔔 TRG_TRAIN_EXT_COM" | Trigger | MD | train_ext_com.md |
 | B22 | TRG_AUDIT_LEGACY | TriggerAuditLegacy | "🔔 TRG_AUDIT_LEGACY" | Trigger | MD | audit_legacy.md |
 | B23 | TRG_PURGE_AI | TriggerPurgeAI | "🔔 TRG_PURGE_AI" | Trigger | MD | purge_ai.md |

--- a/core/data/mtx/README.md
+++ b/core/data/mtx/README.md
@@ -9,7 +9,7 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../../BACKUP/](../../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../../bk_temp/](../../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../../../backup/](../../../backup/)
 
 ## 3. Crossref y Mapping
@@ -38,9 +38,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../../../legacy/](../../../legacy/) o [../../../tmp_staging/](../../../tmp_staging/)
 2. **Staging / MIG:** [../../../mig/](../../../mig/)
 3. **Consolidación / CORE:** [../../](../../)
-4. **Backup / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../BACKUP/](../../../BACKUP/)
+4. **bk_temp / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../bk_temp/](../../../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/core/data/mtx/rw_b_assets_classification_matrix_v_1_20250729.md
+++ b/core/data/mtx/rw_b_assets_classification_matrix_v_1_20250729.md
@@ -102,12 +102,12 @@ Formato de código compuesto final: `SRC·STG·ROLE` (ej. `INT·DR·TL`).
 3. Auditoría trimestral `WF_AUDIT_EXT_OFF`.
 
 ### INT·BK·REF — Respaldo interno de referencia
-1. Guardar en `/BACKUP/int/`.
+1. Guardar en `/bk_temp/int/`.
 2. Etiquetar `STA=BCK` y registrar en BIT.
-3. Auditoría semestral `WF_AUDIT_BACKUP`.
+3. Auditoría semestral `WF_AUDIT_bk_temp`.
 
 ### EXT‑OFF·BK·CORE — Respaldo externo oficial
-1. Almacenar en `/BACKUP/ext_off/` con checksum.
+1. Almacenar en `/bk_temp/ext_off/` con checksum.
 2. Revisar licencias antes de archivarlo.
 3. Auditoría anual `WF_AUDIT_EXT_OFF`.
 
@@ -132,14 +132,14 @@ Formato de código compuesto final: `SRC·STG·ROLE` (ej. `INT·DR·TL`).
 3. Auditoría `WF_AUDIT_LEGACY`.
 
 ### EXT‑COM·BK·REF — Respaldo comunidad externa
-1. Guardar en `/BACKUP/ext_com/`.
+1. Guardar en `/bk_temp/ext_com/`.
 2. Verificar checksum y procedencia.
-3. Auditoría anual `WF_AUDIT_BACKUP`.
+3. Auditoría anual `WF_AUDIT_bk_temp`.
 
 ### AI·BK·TL — Respaldo IA para entrenamiento
-1. Archivar en `/BACKUP/ai/` con versión.
+1. Archivar en `/bk_temp/ai/` con versión.
 2. Registrar en BIT con `STA=BCK`.
-3. Auditoría `WF_AUDIT_BACKUP`.
+3. Auditoría `WF_AUDIT_bk_temp`.
 
 ### AI·PG·TL — Purgatorio de entrenamiento IA
 1. Mover a `/PURGATORIO/ai/` cuando queda obsoleto.

--- a/core/data/repo_monorepo_packages_blueprint_v1_20250731.md
+++ b/core/data/repo_monorepo_packages_blueprint_v1_20250731.md
@@ -34,7 +34,7 @@ Repo Root /
 ├── SCR/                       # Scripts de soporte
 ├── DATA/                      # Datasets y matrices comunes
 ├── LOG/                       # Logs y changelogs
-├── BACKUP/                    # Snapshots periódicos
+├── bk_temp/                    # Snapshots periódicos
 ├── TMP/                       # Scratchpad y archivos temporales
 └── MIG/                    # Outputs de migración
 ```
@@ -63,7 +63,7 @@ packages/pkg_nombre/
 
 1. **Desarrollo local** en `packages/pkg_x/src` con seguimiento de tests.
 2. **Auditoría ligera** mediante scripts en `WF/` y registros en `LOG/`.
-3. **Consolidación** del package: cuando se estabiliza, se integran snapshots en `BACKUP/`.
+3. **Consolidación** del package: cuando se estabiliza, se integran snapshots en `bk_temp/`.
 4. **Migración** o integración mayor se gestiona desde `MIG/` siguiendo el DirArchPlan v5.
 
 ---

--- a/core/data/rulset/README.md
+++ b/core/data/rulset/README.md
@@ -9,7 +9,7 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../../BACKUP/](../../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../../bk_temp/](../../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../../../backup/](../../../backup/)
 
 ## 3. Crossref y Mapping
@@ -38,9 +38,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../../../legacy/](../../../legacy/) o [../../../tmp_staging/](../../../tmp_staging/)
 2. **Staging / MIG:** [../../../mig/](../../../mig/)
 3. **Consolidación / CORE:** [../../](../../)
-4. **Backup / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../BACKUP/](../../../BACKUP/)
+4. **bk_temp / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../bk_temp/](../../../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/core/data/template/README.md
+++ b/core/data/template/README.md
@@ -9,7 +9,7 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../../BACKUP/](../../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../../bk_temp/](../../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../../../backup/](../../../backup/)
 
 ## 3. Crossref y Mapping
@@ -38,9 +38,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../../../legacy/](../../../legacy/) o [../../../tmp_staging/](../../../tmp_staging/)
 2. **Staging / MIG:** [../../../mig/](../../../mig/)
 3. **Consolidación / CORE:** [../../](../../)
-4. **Backup / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../BACKUP/](../../../BACKUP/)
+4. **bk_temp / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../bk_temp/](../../../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/core/doc/README_bucket_template - copia.md
+++ b/core/doc/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/core/doc/audio/README.md
+++ b/core/doc/audio/README.md
@@ -9,7 +9,7 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../../BACKUP/](../../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../../bk_temp/](../../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../../../backup/](../../../backup/)
 
 ## 3. Crossref y Mapping
@@ -38,9 +38,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../../../legacy/](../../../legacy/) o [../../../tmp_staging/](../../../tmp_staging/)
 2. **Staging / MIG:** [../../../mig/](../../../mig/)
 3. **Consolidación / CORE:** [../../](../../)
-4. **Backup / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../BACKUP/](../../../BACKUP/)
+4. **bk_temp / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../bk_temp/](../../../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/core/doc/image/README_bucket_template - copia.md
+++ b/core/doc/image/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/core/doc/library/README.md
+++ b/core/doc/library/README.md
@@ -9,7 +9,7 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../../BACKUP/](../../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../../bk_temp/](../../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../../../backup/](../../../backup/)
 
 ## 3. Crossref y Mapping
@@ -38,9 +38,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../../../legacy/](../../../legacy/) o [../../../tmp_staging/](../../../tmp_staging/)
 2. **Staging / MIG:** [../../../mig/](../../../mig/)
 3. **Consolidación / CORE:** [../../](../../)
-4. **Backup / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../BACKUP/](../../../BACKUP/)
+4. **bk_temp / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../bk_temp/](../../../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/core/doc/library_ext/README.md
+++ b/core/doc/library_ext/README.md
@@ -9,7 +9,7 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../../BACKUP/](../../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../../bk_temp/](../../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../../../backup/](../../../backup/)
 
 ## 3. Crossref y Mapping
@@ -38,9 +38,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../../../legacy/](../../../legacy/) o [../../../tmp_staging/](../../../tmp_staging/)
 2. **Staging / MIG:** [../../../mig/](../../../mig/)
 3. **Consolidación / CORE:** [../../](../../)
-4. **Backup / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../BACKUP/](../../../BACKUP/)
+4. **bk_temp / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../bk_temp/](../../../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/core/doc/onbrd/README.md
+++ b/core/doc/onbrd/README.md
@@ -9,7 +9,7 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../../BACKUP/](../../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../../bk_temp/](../../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../../../backup/](../../../backup/)
 
 ## 3. Crossref y Mapping
@@ -38,9 +38,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../../../legacy/](../../../legacy/) o [../../../tmp_staging/](../../../tmp_staging/)
 2. **Staging / MIG:** [../../../mig/](../../../mig/)
 3. **Consolidación / CORE:** [../../](../../)
-4. **Backup / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../BACKUP/](../../../BACKUP/)
+4. **bk_temp / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../bk_temp/](../../../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/core/doc/template/README.md
+++ b/core/doc/template/README.md
@@ -9,7 +9,7 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../../BACKUP/](../../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../../bk_temp/](../../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../../../backup/](../../../backup/)
 
 ## 3. Crossref y Mapping
@@ -38,9 +38,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../../../legacy/](../../../legacy/) o [../../../tmp_staging/](../../../tmp_staging/)
 2. **Staging / MIG:** [../../../mig/](../../../mig/)
 3. **Consolidación / CORE:** [../../](../../)
-4. **Backup / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../BACKUP/](../../../BACKUP/)
+4. **bk_temp / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../bk_temp/](../../../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/core/doc/video/README.md
+++ b/core/doc/video/README.md
@@ -9,7 +9,7 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../../BACKUP/](../../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../../bk_temp/](../../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../../../backup/](../../../backup/)
 
 ## 3. Crossref y Mapping
@@ -38,9 +38,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../../../legacy/](../../../legacy/) o [../../../tmp_staging/](../../../tmp_staging/)
 2. **Staging / MIG:** [../../../mig/](../../../mig/)
 3. **Consolidación / CORE:** [../../](../../)
-4. **Backup / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../BACKUP/](../../../BACKUP/)
+4. **bk_temp / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../bk_temp/](../../../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/core/kns/README.md
+++ b/core/kns/README.md
@@ -9,7 +9,7 @@
 Breve descripción del propósito y alcance de este bucket/carpeta. Completar según corresponda.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../BACKUP/](../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../bk_temp/](../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../../backup/](../../backup/)
 
 ## 3. Crossref y Mapping
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../../legacy/](../../legacy/) o [../../tmp_staging/](../../tmp_staging/)
 2. **Staging / MIG:** [../../mig/](../../mig/)
 3. **Consolidación / CORE:** [../](../)
-4. **Backup / Eliminación:** [../../backup/](../../backup/) y/o [../../BACKUP/](../../BACKUP/)
+4. **bk_temp / Eliminación:** [../../backup/](../../backup/) y/o [../../bk_temp/](../../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/core/kns/ai_learn/README_bucket_template - copia.md
+++ b/core/kns/ai_learn/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/core/kns/ai_learn/eval/README_bucket_template - copia.md
+++ b/core/kns/ai_learn/eval/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/core/kns/ai_learn/feed/README_bucket_template - copia.md
+++ b/core/kns/ai_learn/feed/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/core/kns/ai_learn/learn/README_bucket_template - copia.md
+++ b/core/kns/ai_learn/learn/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/core/kns/ai_learn/rel/README_bucket_template - copia.md
+++ b/core/kns/ai_learn/rel/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/core/kns/ai_learn/shot/README_bucket_template - copia.md
+++ b/core/kns/ai_learn/shot/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/core/kns/ai_learn/trn/README_bucket_template - copia.md
+++ b/core/kns/ai_learn/trn/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/core/kns/ai_learn/tune/README_bucket_template - copia.md
+++ b/core/kns/ai_learn/tune/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/core/kns/chkp/README_bucket_template - copia.md
+++ b/core/kns/chkp/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/core/kns/chkp/aingz_platform/README_bucket_template - copia.md
+++ b/core/kns/chkp/aingz_platform/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/core/kns/chkp/projects/README_bucket_template - copia.md
+++ b/core/kns/chkp/projects/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/core/kns/ctx/README_bucket_template - copia.md
+++ b/core/kns/ctx/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/core/kns/ctx/aingz_platform/README_bucket_template - copia.md
+++ b/core/kns/ctx/aingz_platform/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/core/kns/ctx/projects/README_bucket_template - copia.md
+++ b/core/kns/ctx/projects/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/core/kns/ctx/snaphots_ai/README_bucket_template - copia.md
+++ b/core/kns/ctx/snaphots_ai/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/core/kns/glossary/rw_b_glosario_code_v_2_20250729.md
+++ b/core/kns/glossary/rw_b_glosario_code_v_2_20250729.md
@@ -46,7 +46,7 @@
 | B17 | TRG_AUDIT_TL | TriggerAuditTL | Disparador auditoría TL | Ciclo TL | event hooks |
 | B18 | TRG_CONSOLIDATE_TL | TriggerConsolidateTL | Disparador consolidación TL | Ciclo TL | event hooks |
 | B19 | TRG_AUDIT_EXT_OFF | TriggerAuditExternalOfficial | Disparador auditoría de assets externos oficiales | Ciclo EXT | event hooks |
-| B20 | TRG_AUDIT_BACKUP | TriggerAuditBackup | Disparador auditoría de respaldos | Ciclo BK | event hooks |
+| B20 | TRG_AUDIT_bk_temp | TriggerAuditBackup | Disparador auditoría de respaldos | Ciclo BK | event hooks |
 | B21 | TRG_TRAIN_EXT_COM | TriggerTrainExternalCommunity | Disparador training assets comunidad externa | Ciclo TL | event hooks |
 | B22 | TRG_AUDIT_LEGACY | TriggerAuditLegacy | Disparador auditoría de archivos legacy | Ciclo LEG | event hooks |
 | B23 | TRG_PURGE_AI | TriggerPurgeAI | Disparador purga de datos IA | Ciclo AI | event hooks |

--- a/core/kns/glossary/rw_b_naming_convention.md
+++ b/core/kns/glossary/rw_b_naming_convention.md
@@ -8,14 +8,14 @@
 ## 1. Convención general
 - Usa `snake_case` para nombres de archivos y carpetas.
 - Reserva `UPPER_CASE` únicamente para etapas del pipeline:
-  `LEGACY`, `TMP`, `MIG`, `CORE`, `BACKUP`.
+  `LEGACY`, `TMP`, `MIG`, `CORE`, `bk_temp`.
 
 ## 2. Ejemplos
 | Tipo      | Correcto          | Incorrecto        |
 |-----------|-------------------|-------------------|
 | Script    | `my_script.py`    | `MyScript.py`     |
 | Carpeta   | `data_files/`     | `DataFiles/`      |
-| Etapa     | `BACKUP/`         | `backup/`         |
+| Etapa     | `bk_temp/`         | `backup/`         |
 
 Esta guía aplica a nuevas incorporaciones y ayuda a mantener
 coherencia en el repositorio. Las rutas heredadas se ajustarán

--- a/core/log/README_bucket_template - copia.md
+++ b/core/log/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/core/log/bitacoras/README_bucket_template - copia.md
+++ b/core/log/bitacoras/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/core/log/changelog/README_bucket_template - copia.md
+++ b/core/log/changelog/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/core/log/trazabilidad_total/README_bucket_template - copia.md
+++ b/core/log/trazabilidad_total/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/core/rw_b_diccionario_code_triggers_v_2_20250729.md
+++ b/core/rw_b_diccionario_code_triggers_v_2_20250729.md
@@ -32,7 +32,7 @@
 | B17 | TRG_AUDIT_TL | TriggerAuditTL | "🔔 TRG_AUDIT_TL" | Trigger | MD | audit_tl.md |
 | B18 | TRG_CONSOLIDATE_TL | TriggerConsolidateTL | "🔔 TRG_CONSOLIDATE_TL" | Trigger | MD | consolidate_tl.md |
 | B19 | TRG_AUDIT_EXT_OFF | TriggerAuditExternalOfficial | "🔔 TRG_AUDIT_EXT_OFF" | Trigger | MD | audit_ext_off.md |
-| B20 | TRG_AUDIT_BACKUP | TriggerAuditBackup | "🔔 TRG_AUDIT_BACKUP" | Trigger | MD | audit_backup.md |
+| B20 | TRG_AUDIT_bk_temp | TriggerAuditBackup | "🔔 TRG_AUDIT_bk_temp" | Trigger | MD | audit_backup.md |
 | B21 | TRG_TRAIN_EXT_COM | TriggerTrainExternalCommunity | "🔔 TRG_TRAIN_EXT_COM" | Trigger | MD | train_ext_com.md |
 | B22 | TRG_AUDIT_LEGACY | TriggerAuditLegacy | "🔔 TRG_AUDIT_LEGACY" | Trigger | MD | audit_legacy.md |
 | B23 | TRG_PURGE_AI | TriggerPurgeAI | "🔔 TRG_PURGE_AI" | Trigger | MD | purge_ai.md |

--- a/core/scr/README_bucket_template - copia.md
+++ b/core/scr/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/core/wf/README_bucket_template - copia.md
+++ b/core/wf/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/core/wf/audt/README.md
+++ b/core/wf/audt/README.md
@@ -9,7 +9,7 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../../BACKUP/](../../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../../bk_temp/](../../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../../../backup/](../../../backup/)
 
 ## 3. Crossref y Mapping
@@ -38,9 +38,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../../../legacy/](../../../legacy/) o [../../../tmp_staging/](../../../tmp_staging/)
 2. **Staging / MIG:** [../../../mig/](../../../mig/)
 3. **Consolidación / CORE:** [../../](../../)
-4. **Backup / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../BACKUP/](../../../BACKUP/)
+4. **bk_temp / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../bk_temp/](../../../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/core/wf/mig_cons/README.md
+++ b/core/wf/mig_cons/README.md
@@ -9,7 +9,7 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../../BACKUP/](../../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../../bk_temp/](../../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../../../backup/](../../../backup/)
 
 ## 3. Crossref y Mapping
@@ -38,9 +38,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../../../legacy/](../../../legacy/) o [../../../tmp_staging/](../../../tmp_staging/)
 2. **Staging / MIG:** [../../../mig/](../../../mig/)
 3. **Consolidación / CORE:** [../../](../../)
-4. **Backup / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../BACKUP/](../../../BACKUP/)
+4. **bk_temp / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../bk_temp/](../../../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/core/wf/relv/README_bucket_template - copia.md
+++ b/core/wf/relv/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/core/wf/tareas_acciones/README_bucket_template - copia.md
+++ b/core/wf/tareas_acciones/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -9,12 +9,12 @@
 Definiciones y scripts de infraestructura.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../BACKUP/](../BACKUP/)
+- Carpeta de snapshots relacionada: [../bk_temp/](../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../backup/](../backup/)
 
 ## 3. Crossref y Mapping
 - **Referencia ascendente:** `[../]`
-- **Referencias laterales:** [../.git/], [../.pytest_cache/], [../BACKUP/], [../__pycache__/], [../apps/], [../backup/], [../connectors/], [../core/], [../legacy/], [../legacy_old/], [../log/], [../mig/], [../packages/], [../scripts/], [../tmp_staging/]
+- **Referencias laterales:** [../.git/], [../.pytest_cache/], [../bk_temp/], [../__pycache__/], [../apps/], [../backup/], [../connectors/], [../core/], [../legacy/], [../legacy_old/], [../log/], [../mig/], [../packages/], [../scripts/], [../tmp_staging/]
 - **Buckets destino típicos:** `[../DESTINO/]`
 - **Crossref central:** [Mapa Global](../core/data/crossref_mapping_buckets_aingz_platform_v_1_20250731.md)
 - **Flujos/Pipelines relevantes:** [pipelines/README.md](pipelines/README.md)
@@ -40,9 +40,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../legacy/](../legacy/) o [../tmp_staging/](../tmp_staging/)
 2. **Staging / MIG:** [../mig/](../mig/)
 3. **Consolidación / CORE:** [../core/](../core/)
-4. **Backup / Eliminación:** [../backup/](../backup/) y/o [../BACKUP/](../BACKUP/)
+4. **bk_temp / Eliminación:** [../backup/](../backup/) y/o [../bk_temp/](../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/infra/git/README.md
+++ b/infra/git/README.md
@@ -9,7 +9,7 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../BACKUP/](../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../bk_temp/](../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../../backup/](../../backup/)
 
 ## 3. Crossref y Mapping
@@ -37,9 +37,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../../legacy/](../../legacy/) o [../../tmp_staging/](../../tmp_staging/)
 2. **Staging / MIG:** [../../mig/](../../mig/)
 3. **Consolidación / CORE:** [../../core/](../../core/)
-4. **Backup / Eliminación:** [../../backup/](../../backup/) y/o [../../BACKUP/](../../BACKUP/)
+4. **bk_temp / Eliminación:** [../../backup/](../../backup/) y/o [../../bk_temp/](../../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/infra/pipelines/README.md
+++ b/infra/pipelines/README.md
@@ -9,7 +9,7 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../BACKUP/](../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../bk_temp/](../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../../backup/](../../backup/)
 
 ## 3. Crossref y Mapping
@@ -37,9 +37,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../../legacy/](../../legacy/) o [../../tmp_staging/](../../tmp_staging/)
 2. **Staging / MIG:** [../../mig/](../../mig/)
 3. **Consolidación / CORE:** [../../core/](../../core/)
-4. **Backup / Eliminación:** [../../backup/](../../backup/) y/o [../../BACKUP/](../../BACKUP/)
+4. **bk_temp / Eliminación:** [../../backup/](../../backup/) y/o [../../bk_temp/](../../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/infra/scr/README.md
+++ b/infra/scr/README.md
@@ -9,7 +9,7 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../BACKUP/](../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../bk_temp/](../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../../backup/](../../backup/)
 
 ## 3. Crossref y Mapping
@@ -37,9 +37,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../../legacy/](../../legacy/) o [../../tmp_staging/](../../tmp_staging/)
 2. **Staging / MIG:** [../../mig/](../../mig/)
 3. **Consolidación / CORE:** [../../core/](../../core/)
-4. **Backup / Eliminación:** [../../backup/](../../backup/) y/o [../../BACKUP/](../../BACKUP/)
+4. **bk_temp / Eliminación:** [../../backup/](../../backup/) y/o [../../bk_temp/](../../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/infra/test/README.md
+++ b/infra/test/README.md
@@ -9,7 +9,7 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../BACKUP/](../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../bk_temp/](../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../../backup/](../../backup/)
 
 ## 3. Crossref y Mapping
@@ -37,9 +37,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../../legacy/](../../legacy/) o [../../tmp_staging/](../../tmp_staging/)
 2. **Staging / MIG:** [../../mig/](../../mig/)
 3. **Consolidación / CORE:** [../../core/](../../core/)
-4. **Backup / Eliminación:** [../../backup/](../../backup/) y/o [../../BACKUP/](../../BACKUP/)
+4. **bk_temp / Eliminación:** [../../backup/](../../backup/) y/o [../../bk_temp/](../../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/legacy/README.md
+++ b/legacy/README.md
@@ -9,12 +9,12 @@
 Fuentes legadas pendientes de migración.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../BACKUP/](../BACKUP/)
+- Carpeta de snapshots relacionada: [../bk_temp/](../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../backup/](../backup/)
 
 ## 3. Crossref y Mapping
 - **Referencia ascendente:** `[../]`
-- **Referencias laterales:** [../.git/], [../.pytest_cache/], [../BACKUP/], [../__pycache__/], [../apps/], [../backup/], [../connectors/], [../core/], [../infra/], [../legacy_old/], [../log/], [../mig/], [../packages/], [../scripts/], [../tmp_staging/]
+- **Referencias laterales:** [../.git/], [../.pytest_cache/], [../bk_temp/], [../__pycache__/], [../apps/], [../backup/], [../connectors/], [../core/], [../infra/], [../legacy_old/], [../log/], [../mig/], [../packages/], [../scripts/], [../tmp_staging/]
 - **Buckets destino típicos:** `[../DESTINO/]`
 - **Crossref central:** [Mapa Global](../core/data/crossref_mapping_buckets_aingz_platform_v_1_20250731.md)
 - **Flujos/Pipelines relevantes:** [../infra/pipelines/README.md](../infra/pipelines/README.md)
@@ -41,10 +41,10 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [./](./) o [../tmp_staging/](../tmp_staging/)
 2. **Staging / MIG:** [../mig/](../mig/)
 3. **Consolidación / CORE:** [../core/](../core/)
-4. **Backup / Eliminación:** [../backup/](../backup/) y/o [../BACKUP/](../BACKUP/)
+4. **bk_temp / Eliminación:** [../backup/](../backup/) y/o [../bk_temp/](../bk_temp/)
 
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/legacy/data/README.md
+++ b/legacy/data/README.md
@@ -9,7 +9,7 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../BACKUP/](../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../bk_temp/](../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../../backup/](../../backup/)
 
 ## 3. Crossref y Mapping
@@ -40,9 +40,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../](../) o [../../tmp_staging/](../../tmp_staging/)
 2. **Staging / MIG:** [../../mig/](../../mig/)
 3. **Consolidación / CORE:** [../../core/](../../core/)
-4. **Backup / Eliminación:** [../../backup/](../../backup/) y/o [../../BACKUP/](../../BACKUP/)
+4. **bk_temp / Eliminación:** [../../backup/](../../backup/) y/o [../../bk_temp/](../../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/legacy/data/mplan/README.md
+++ b/legacy/data/mplan/README.md
@@ -9,7 +9,7 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../../BACKUP/](../../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../../bk_temp/](../../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../../../backup/](../../../backup/)
 
 ## 3. Crossref y Mapping
@@ -38,9 +38,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../../](../../) o [../../../tmp_staging/](../../../tmp_staging/)
 2. **Staging / MIG:** [../../../mig/](../../../mig/)
 3. **Consolidación / CORE:** [../../../core/](../../../core/)
-4. **Backup / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../BACKUP/](../../../BACKUP/)
+4. **bk_temp / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../bk_temp/](../../../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/legacy/data/mtx/README.md
+++ b/legacy/data/mtx/README.md
@@ -9,7 +9,7 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../../BACKUP/](../../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../../bk_temp/](../../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../../../backup/](../../../backup/)
 
 ## 3. Crossref y Mapping
@@ -38,9 +38,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../../](../../) o [../../../tmp_staging/](../../../tmp_staging/)
 2. **Staging / MIG:** [../../../mig/](../../../mig/)
 3. **Consolidación / CORE:** [../../../core/](../../../core/)
-4. **Backup / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../BACKUP/](../../../BACKUP/)
+4. **bk_temp / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../bk_temp/](../../../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/legacy/data/rulset/README.md
+++ b/legacy/data/rulset/README.md
@@ -9,7 +9,7 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../../BACKUP/](../../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../../bk_temp/](../../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../../../backup/](../../../backup/)
 
 ## 3. Crossref y Mapping
@@ -38,9 +38,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../../](../../) o [../../../tmp_staging/](../../../tmp_staging/)
 2. **Staging / MIG:** [../../../mig/](../../../mig/)
 3. **Consolidación / CORE:** [../../../core/](../../../core/)
-4. **Backup / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../BACKUP/](../../../BACKUP/)
+4. **bk_temp / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../bk_temp/](../../../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/legacy/data/template/README.md
+++ b/legacy/data/template/README.md
@@ -9,7 +9,7 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../../BACKUP/](../../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../../bk_temp/](../../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../../../backup/](../../../backup/)
 
 ## 3. Crossref y Mapping
@@ -38,9 +38,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../../](../../) o [../../../tmp_staging/](../../../tmp_staging/)
 2. **Staging / MIG:** [../../../mig/](../../../mig/)
 3. **Consolidación / CORE:** [../../../core/](../../../core/)
-4. **Backup / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../BACKUP/](../../../BACKUP/)
+4. **bk_temp / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../bk_temp/](../../../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/legacy/doc/README_bucket_template - copia.md
+++ b/legacy/doc/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/legacy/doc/audio/README.md
+++ b/legacy/doc/audio/README.md
@@ -9,7 +9,7 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../../BACKUP/](../../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../../bk_temp/](../../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../../../backup/](../../../backup/)
 
 ## 3. Crossref y Mapping
@@ -38,9 +38,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../../](../../) o [../../../tmp_staging/](../../../tmp_staging/)
 2. **Staging / MIG:** [../../../mig/](../../../mig/)
 3. **Consolidación / CORE:** [../../../core/](../../../core/)
-4. **Backup / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../BACKUP/](../../../BACKUP/)
+4. **bk_temp / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../bk_temp/](../../../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/legacy/doc/image/README_bucket_template - copia.md
+++ b/legacy/doc/image/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/legacy/doc/library/README.md
+++ b/legacy/doc/library/README.md
@@ -9,7 +9,7 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../../BACKUP/](../../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../../bk_temp/](../../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../../../backup/](../../../backup/)
 
 ## 3. Crossref y Mapping
@@ -38,9 +38,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../../](../../) o [../../../tmp_staging/](../../../tmp_staging/)
 2. **Staging / MIG:** [../../../mig/](../../../mig/)
 3. **Consolidación / CORE:** [../../../core/](../../../core/)
-4. **Backup / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../BACKUP/](../../../BACKUP/)
+4. **bk_temp / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../bk_temp/](../../../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/legacy/doc/library_ext/README.md
+++ b/legacy/doc/library_ext/README.md
@@ -9,7 +9,7 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../../BACKUP/](../../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../../bk_temp/](../../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../../../backup/](../../../backup/)
 
 ## 3. Crossref y Mapping
@@ -38,9 +38,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../../](../../) o [../../../tmp_staging/](../../../tmp_staging/)
 2. **Staging / MIG:** [../../../mig/](../../../mig/)
 3. **Consolidación / CORE:** [../../../core/](../../../core/)
-4. **Backup / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../BACKUP/](../../../BACKUP/)
+4. **bk_temp / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../bk_temp/](../../../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/legacy/doc/onbrd/README.md
+++ b/legacy/doc/onbrd/README.md
@@ -9,7 +9,7 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../../BACKUP/](../../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../../bk_temp/](../../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../../../backup/](../../../backup/)
 
 ## 3. Crossref y Mapping
@@ -38,9 +38,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../../](../../) o [../../../tmp_staging/](../../../tmp_staging/)
 2. **Staging / MIG:** [../../../mig/](../../../mig/)
 3. **Consolidación / CORE:** [../../../core/](../../../core/)
-4. **Backup / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../BACKUP/](../../../BACKUP/)
+4. **bk_temp / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../bk_temp/](../../../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/legacy/doc/template/README.md
+++ b/legacy/doc/template/README.md
@@ -9,7 +9,7 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../../BACKUP/](../../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../../bk_temp/](../../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../../../backup/](../../../backup/)
 
 ## 3. Crossref y Mapping
@@ -38,9 +38,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../../](../../) o [../../../tmp_staging/](../../../tmp_staging/)
 2. **Staging / MIG:** [../../../mig/](../../../mig/)
 3. **Consolidación / CORE:** [../../../core/](../../../core/)
-4. **Backup / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../BACKUP/](../../../BACKUP/)
+4. **bk_temp / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../bk_temp/](../../../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/legacy/doc/video/README.md
+++ b/legacy/doc/video/README.md
@@ -9,7 +9,7 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../../BACKUP/](../../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../../bk_temp/](../../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../../../backup/](../../../backup/)
 
 ## 3. Crossref y Mapping
@@ -38,9 +38,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../../](../../) o [../../../tmp_staging/](../../../tmp_staging/)
 2. **Staging / MIG:** [../../../mig/](../../../mig/)
 3. **Consolidación / CORE:** [../../../core/](../../../core/)
-4. **Backup / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../BACKUP/](../../../BACKUP/)
+4. **bk_temp / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../bk_temp/](../../../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/legacy/kns/README_bucket_template - copia.md
+++ b/legacy/kns/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/legacy/kns/ai_learn/README_bucket_template - copia.md
+++ b/legacy/kns/ai_learn/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/legacy/kns/ai_learn/eval/README_bucket_template - copia.md
+++ b/legacy/kns/ai_learn/eval/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/legacy/kns/ai_learn/feed/README_bucket_template - copia.md
+++ b/legacy/kns/ai_learn/feed/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/legacy/kns/ai_learn/learn/README_bucket_template - copia.md
+++ b/legacy/kns/ai_learn/learn/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/legacy/kns/ai_learn/rel/README_bucket_template - copia.md
+++ b/legacy/kns/ai_learn/rel/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/legacy/kns/ai_learn/shot/README_bucket_template - copia.md
+++ b/legacy/kns/ai_learn/shot/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/legacy/kns/ai_learn/trn/README_bucket_template - copia.md
+++ b/legacy/kns/ai_learn/trn/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/legacy/kns/ai_learn/tune/README_bucket_template - copia.md
+++ b/legacy/kns/ai_learn/tune/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/legacy/kns/chkp/README_bucket_template - copia.md
+++ b/legacy/kns/chkp/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/legacy/kns/chkp/aingz_platform/README_bucket_template - copia.md
+++ b/legacy/kns/chkp/aingz_platform/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/legacy/kns/chkp/projects/README_bucket_template - copia.md
+++ b/legacy/kns/chkp/projects/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/legacy/kns/ctx/README_bucket_template - copia.md
+++ b/legacy/kns/ctx/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/legacy/kns/ctx/aingz_platform/README_bucket_template - copia.md
+++ b/legacy/kns/ctx/aingz_platform/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/legacy/kns/ctx/projects/README_bucket_template - copia.md
+++ b/legacy/kns/ctx/projects/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/legacy/kns/ctx/snaphots_ai/README_bucket_template - copia.md
+++ b/legacy/kns/ctx/snaphots_ai/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/legacy/log/README_bucket_template - copia.md
+++ b/legacy/log/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/legacy/log/bitacoras/README_bucket_template - copia.md
+++ b/legacy/log/bitacoras/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/legacy/log/changelog/README_bucket_template - copia.md
+++ b/legacy/log/changelog/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/legacy/log/trazabilidad_total/README_bucket_template - copia.md
+++ b/legacy/log/trazabilidad_total/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/legacy/scr/README_bucket_template - copia.md
+++ b/legacy/scr/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/legacy/wf/README_bucket_template - copia.md
+++ b/legacy/wf/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/legacy/wf/audt/README.md
+++ b/legacy/wf/audt/README.md
@@ -9,7 +9,7 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../../BACKUP/](../../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../../bk_temp/](../../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../../../backup/](../../../backup/)
 
 ## 3. Crossref y Mapping
@@ -38,9 +38,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../../](../../) o [../../../tmp_staging/](../../../tmp_staging/)
 2. **Staging / MIG:** [../../../mig/](../../../mig/)
 3. **Consolidación / CORE:** [../../../core/](../../../core/)
-4. **Backup / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../BACKUP/](../../../BACKUP/)
+4. **bk_temp / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../bk_temp/](../../../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/legacy/wf/mig_cons/README.md
+++ b/legacy/wf/mig_cons/README.md
@@ -9,7 +9,7 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../../BACKUP/](../../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../../bk_temp/](../../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../../../backup/](../../../backup/)
 
 ## 3. Crossref y Mapping
@@ -38,9 +38,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../../](../../) o [../../../tmp_staging/](../../../tmp_staging/)
 2. **Staging / MIG:** [../../../mig/](../../../mig/)
 3. **Consolidación / CORE:** [../../../core/](../../../core/)
-4. **Backup / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../BACKUP/](../../../BACKUP/)
+4. **bk_temp / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../bk_temp/](../../../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/legacy/wf/relv/README_bucket_template - copia.md
+++ b/legacy/wf/relv/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/legacy/wf/tareas_acciones/README_bucket_template - copia.md
+++ b/legacy/wf/tareas_acciones/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/log/README.md
+++ b/log/README.md
@@ -9,12 +9,12 @@
 Registros y bitácoras operativas.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../BACKUP/](../BACKUP/)
+- Carpeta de snapshots relacionada: [../bk_temp/](../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../backup/](../backup/)
 
 ## 3. Crossref y Mapping
 - **Referencia ascendente:** `[../]`
-- **Referencias laterales:** [../.git/], [../.pytest_cache/], [../BACKUP/], [../__pycache__/], [../apps/], [../backup/], [../connectors/], [../core/], [../infra/], [../legacy/], [../legacy_old/], [../mig/], [../packages/], [../scripts/], [../tmp_staging/]
+- **Referencias laterales:** [../.git/], [../.pytest_cache/], [../bk_temp/], [../__pycache__/], [../apps/], [../backup/], [../connectors/], [../core/], [../infra/], [../legacy/], [../legacy_old/], [../mig/], [../packages/], [../scripts/], [../tmp_staging/]
 - **Buckets destino típicos:** `[../DESTINO/]`
 - **Crossref central:** [Mapa Global](../core/data/crossref_mapping_buckets_aingz_platform_v_1_20250731.md)
 - **Flujos/Pipelines relevantes:** [../infra/pipelines/README.md](../infra/pipelines/README.md)
@@ -38,9 +38,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../legacy/](../legacy/) o [../tmp_staging/](../tmp_staging/)
 2. **Staging / MIG:** [../mig/](../mig/)
 3. **Consolidación / CORE:** [../core/](../core/)
-4. **Backup / Eliminación:** [../backup/](../backup/) y/o [../BACKUP/](../BACKUP/)
+4. **bk_temp / Eliminación:** [../backup/](../backup/) y/o [../bk_temp/](../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/log/bitacoras/README.md
+++ b/log/bitacoras/README.md
@@ -9,7 +9,7 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../BACKUP/](../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../bk_temp/](../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../../backup/](../../backup/)
 
 ## 3. Crossref y Mapping
@@ -37,9 +37,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../../legacy/](../../legacy/) o [../../tmp_staging/](../../tmp_staging/)
 2. **Staging / MIG:** [../../mig/](../../mig/)
 3. **Consolidación / CORE:** [../../core/](../../core/)
-4. **Backup / Eliminación:** [../../backup/](../../backup/) y/o [../../BACKUP/](../../BACKUP/)
+4. **bk_temp / Eliminación:** [../../backup/](../../backup/) y/o [../../bk_temp/](../../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/log/changelog/README.md
+++ b/log/changelog/README.md
@@ -9,7 +9,7 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../BACKUP/](../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../bk_temp/](../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../../backup/](../../backup/)
 
 ## 3. Crossref y Mapping
@@ -37,9 +37,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../../legacy/](../../legacy/) o [../../tmp_staging/](../../tmp_staging/)
 2. **Staging / MIG:** [../../mig/](../../mig/)
 3. **Consolidación / CORE:** [../../core/](../../core/)
-4. **Backup / Eliminación:** [../../backup/](../../backup/) y/o [../../BACKUP/](../../BACKUP/)
+4. **bk_temp / Eliminación:** [../../backup/](../../backup/) y/o [../../bk_temp/](../../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/log/trazabilidad_total/README.md
+++ b/log/trazabilidad_total/README.md
@@ -9,7 +9,7 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../BACKUP/](../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../bk_temp/](../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../../backup/](../../backup/)
 
 ## 3. Crossref y Mapping
@@ -37,9 +37,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../../legacy/](../../legacy/) o [../../tmp_staging/](../../tmp_staging/)
 2. **Staging / MIG:** [../../mig/](../../mig/)
 3. **Consolidación / CORE:** [../../core/](../../core/)
-4. **Backup / Eliminación:** [../../backup/](../../backup/) y/o [../../BACKUP/](../../BACKUP/)
+4. **bk_temp / Eliminación:** [../../backup/](../../backup/) y/o [../../bk_temp/](../../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/mig/README.md
+++ b/mig/README.md
@@ -9,12 +9,12 @@
 Procesos y scripts de migración.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../BACKUP/](../BACKUP/)
+- Carpeta de snapshots relacionada: [../bk_temp/](../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../backup/](../backup/)
 
 ## 3. Crossref y Mapping
 - **Referencia ascendente:** `[../]`
-- **Referencias laterales:** [../.git/], [../.pytest_cache/], [../BACKUP/], [../__pycache__/], [../apps/], [../backup/], [../connectors/], [../core/], [../infra/], [../legacy/], [../legacy_old/], [../log/], [../packages/], [../scripts/], [../tmp_staging/]
+- **Referencias laterales:** [../.git/], [../.pytest_cache/], [../bk_temp/], [../__pycache__/], [../apps/], [../backup/], [../connectors/], [../core/], [../infra/], [../legacy/], [../legacy_old/], [../log/], [../packages/], [../scripts/], [../tmp_staging/]
 - **Buckets destino típicos:** `[../DESTINO/]`
 - **Crossref central:** [Mapa Global](../core/data/crossref_mapping_buckets_aingz_platform_v_1_20250731.md)
 - **Flujos/Pipelines relevantes:** [../infra/pipelines/README.md](../infra/pipelines/README.md)
@@ -42,14 +42,14 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 - [TMP_STAGING](../tmp_staging/)
 - [MIG](./)
 - [CORE](../core/)
-- [backup](../backup/) / [BACKUP final](../BACKUP/)
+- [backup](../backup/) / [bk_temp final](../bk_temp/)
 
 1. **Ingreso / LEGACY o TMP:** [../legacy/](../legacy/) o [../tmp_staging/](../tmp_staging/)
 2. **Staging / MIG:** [./](./)
 3. **Consolidación / CORE:** [../core/](../core/)
-4. **Backup / Eliminación:** [../backup/](../backup/) y/o [../BACKUP/](../BACKUP/)
+4. **bk_temp / Eliminación:** [../backup/](../backup/) y/o [../bk_temp/](../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/mig/data/README.md
+++ b/mig/data/README.md
@@ -9,7 +9,7 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../BACKUP/](../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../bk_temp/](../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../../backup/](../../backup/)
 
 ## 3. Crossref y Mapping
@@ -40,9 +40,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../../legacy/](../../legacy/) o [../../tmp_staging/](../../tmp_staging/)
 2. **Staging / MIG:** [../](../)
 3. **Consolidación / CORE:** [../../core/](../../core/)
-4. **Backup / Eliminación:** [../../backup/](../../backup/) y/o [../../BACKUP/](../../BACKUP/)
+4. **bk_temp / Eliminación:** [../../backup/](../../backup/) y/o [../../bk_temp/](../../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/mig/data/mplan/README.md
+++ b/mig/data/mplan/README.md
@@ -9,7 +9,7 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../../BACKUP/](../../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../../bk_temp/](../../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../../../backup/](../../../backup/)
 
 ## 3. Crossref y Mapping
@@ -38,9 +38,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../../../legacy/](../../../legacy/) o [../../../tmp_staging/](../../../tmp_staging/)
 2. **Staging / MIG:** [../../](../../)
 3. **Consolidación / CORE:** [../../../core/](../../../core/)
-4. **Backup / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../BACKUP/](../../../BACKUP/)
+4. **bk_temp / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../bk_temp/](../../../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/mig/data/mtx/README.md
+++ b/mig/data/mtx/README.md
@@ -9,7 +9,7 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../../BACKUP/](../../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../../bk_temp/](../../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../../../backup/](../../../backup/)
 
 ## 3. Crossref y Mapping
@@ -38,9 +38,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../../../legacy/](../../../legacy/) o [../../../tmp_staging/](../../../tmp_staging/)
 2. **Staging / MIG:** [../../](../../)
 3. **Consolidación / CORE:** [../../../core/](../../../core/)
-4. **Backup / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../BACKUP/](../../../BACKUP/)
+4. **bk_temp / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../bk_temp/](../../../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/mig/data/rulset/README.md
+++ b/mig/data/rulset/README.md
@@ -9,7 +9,7 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../../BACKUP/](../../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../../bk_temp/](../../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../../../backup/](../../../backup/)
 
 ## 3. Crossref y Mapping
@@ -38,9 +38,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../../../legacy/](../../../legacy/) o [../../../tmp_staging/](../../../tmp_staging/)
 2. **Staging / MIG:** [../../](../../)
 3. **Consolidación / CORE:** [../../../core/](../../../core/)
-4. **Backup / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../BACKUP/](../../../BACKUP/)
+4. **bk_temp / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../bk_temp/](../../../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/mig/data/template/README.md
+++ b/mig/data/template/README.md
@@ -9,7 +9,7 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../../BACKUP/](../../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../../bk_temp/](../../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../../../backup/](../../../backup/)
 
 ## 3. Crossref y Mapping
@@ -38,9 +38,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../../../legacy/](../../../legacy/) o [../../../tmp_staging/](../../../tmp_staging/)
 2. **Staging / MIG:** [../../](../../)
 3. **Consolidación / CORE:** [../../../core/](../../../core/)
-4. **Backup / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../BACKUP/](../../../BACKUP/)
+4. **bk_temp / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../bk_temp/](../../../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/mig/doc/README_bucket_template - copia.md
+++ b/mig/doc/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/mig/doc/audio/README.md
+++ b/mig/doc/audio/README.md
@@ -9,7 +9,7 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../../BACKUP/](../../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../../bk_temp/](../../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../../../backup/](../../../backup/)
 
 ## 3. Crossref y Mapping
@@ -38,9 +38,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../../../legacy/](../../../legacy/) o [../../../tmp_staging/](../../../tmp_staging/)
 2. **Staging / MIG:** [../../](../../)
 3. **Consolidación / CORE:** [../../../core/](../../../core/)
-4. **Backup / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../BACKUP/](../../../BACKUP/)
+4. **bk_temp / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../bk_temp/](../../../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/mig/doc/image/README_bucket_template - copia.md
+++ b/mig/doc/image/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/mig/doc/library/README.md
+++ b/mig/doc/library/README.md
@@ -9,7 +9,7 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../../BACKUP/](../../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../../bk_temp/](../../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../../../backup/](../../../backup/)
 
 ## 3. Crossref y Mapping
@@ -38,9 +38,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../../../legacy/](../../../legacy/) o [../../../tmp_staging/](../../../tmp_staging/)
 2. **Staging / MIG:** [../../](../../)
 3. **Consolidación / CORE:** [../../../core/](../../../core/)
-4. **Backup / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../BACKUP/](../../../BACKUP/)
+4. **bk_temp / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../bk_temp/](../../../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/mig/doc/library_ext/README.md
+++ b/mig/doc/library_ext/README.md
@@ -9,7 +9,7 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../../BACKUP/](../../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../../bk_temp/](../../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../../../backup/](../../../backup/)
 
 ## 3. Crossref y Mapping
@@ -38,9 +38,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../../../legacy/](../../../legacy/) o [../../../tmp_staging/](../../../tmp_staging/)
 2. **Staging / MIG:** [../../](../../)
 3. **Consolidación / CORE:** [../../../core/](../../../core/)
-4. **Backup / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../BACKUP/](../../../BACKUP/)
+4. **bk_temp / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../bk_temp/](../../../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/mig/doc/onbrd/README.md
+++ b/mig/doc/onbrd/README.md
@@ -9,7 +9,7 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../../BACKUP/](../../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../../bk_temp/](../../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../../../backup/](../../../backup/)
 
 ## 3. Crossref y Mapping
@@ -38,9 +38,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../../../legacy/](../../../legacy/) o [../../../tmp_staging/](../../../tmp_staging/)
 2. **Staging / MIG:** [../../](../../)
 3. **Consolidación / CORE:** [../../../core/](../../../core/)
-4. **Backup / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../BACKUP/](../../../BACKUP/)
+4. **bk_temp / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../bk_temp/](../../../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/mig/doc/template/README.md
+++ b/mig/doc/template/README.md
@@ -9,7 +9,7 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../../BACKUP/](../../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../../bk_temp/](../../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../../../backup/](../../../backup/)
 
 ## 3. Crossref y Mapping
@@ -38,9 +38,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../../../legacy/](../../../legacy/) o [../../../tmp_staging/](../../../tmp_staging/)
 2. **Staging / MIG:** [../../](../../)
 3. **Consolidación / CORE:** [../../../core/](../../../core/)
-4. **Backup / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../BACKUP/](../../../BACKUP/)
+4. **bk_temp / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../bk_temp/](../../../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/mig/doc/video/README.md
+++ b/mig/doc/video/README.md
@@ -9,7 +9,7 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../../BACKUP/](../../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../../bk_temp/](../../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../../../backup/](../../../backup/)
 
 ## 3. Crossref y Mapping
@@ -38,9 +38,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../../../legacy/](../../../legacy/) o [../../../tmp_staging/](../../../tmp_staging/)
 2. **Staging / MIG:** [../../](../../)
 3. **Consolidación / CORE:** [../../../core/](../../../core/)
-4. **Backup / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../BACKUP/](../../../BACKUP/)
+4. **bk_temp / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../bk_temp/](../../../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/mig/kns/README_bucket_template - copia.md
+++ b/mig/kns/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/mig/kns/ai_learn/README_bucket_template - copia.md
+++ b/mig/kns/ai_learn/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/mig/kns/ai_learn/eval/README_bucket_template - copia.md
+++ b/mig/kns/ai_learn/eval/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/mig/kns/ai_learn/feed/README_bucket_template - copia.md
+++ b/mig/kns/ai_learn/feed/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/mig/kns/ai_learn/learn/README_bucket_template - copia.md
+++ b/mig/kns/ai_learn/learn/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/mig/kns/ai_learn/rel/README_bucket_template - copia.md
+++ b/mig/kns/ai_learn/rel/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/mig/kns/ai_learn/shot/README_bucket_template - copia.md
+++ b/mig/kns/ai_learn/shot/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/mig/kns/ai_learn/trn/README_bucket_template - copia.md
+++ b/mig/kns/ai_learn/trn/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/mig/kns/ai_learn/tune/README_bucket_template - copia.md
+++ b/mig/kns/ai_learn/tune/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/mig/kns/chkp/README_bucket_template - copia.md
+++ b/mig/kns/chkp/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/mig/kns/chkp/aingz_platform/README_bucket_template - copia.md
+++ b/mig/kns/chkp/aingz_platform/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/mig/kns/chkp/projects/README_bucket_template - copia.md
+++ b/mig/kns/chkp/projects/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/mig/kns/ctx/README_bucket_template - copia.md
+++ b/mig/kns/ctx/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/mig/kns/ctx/aingz_platform/README_bucket_template - copia.md
+++ b/mig/kns/ctx/aingz_platform/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/mig/kns/ctx/projects/README_bucket_template - copia.md
+++ b/mig/kns/ctx/projects/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/mig/kns/ctx/snaphots_ai/README_bucket_template - copia.md
+++ b/mig/kns/ctx/snaphots_ai/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/mig/log/README_bucket_template - copia.md
+++ b/mig/log/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/mig/log/bitacoras/README_bucket_template - copia.md
+++ b/mig/log/bitacoras/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/mig/log/changelog/README_bucket_template - copia.md
+++ b/mig/log/changelog/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/mig/log/trazabilidad_total/README_bucket_template - copia.md
+++ b/mig/log/trazabilidad_total/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/mig/scr/README_bucket_template - copia.md
+++ b/mig/scr/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/mig/wf/README_bucket_template - copia.md
+++ b/mig/wf/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/mig/wf/audt/README.md
+++ b/mig/wf/audt/README.md
@@ -9,7 +9,7 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../../BACKUP/](../../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../../bk_temp/](../../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../../../backup/](../../../backup/)
 
 ## 3. Crossref y Mapping
@@ -38,9 +38,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../../../legacy/](../../../legacy/) o [../../../tmp_staging/](../../../tmp_staging/)
 2. **Staging / MIG:** [../../](../../)
 3. **Consolidación / CORE:** [../../../core/](../../../core/)
-4. **Backup / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../BACKUP/](../../../BACKUP/)
+4. **bk_temp / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../bk_temp/](../../../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/mig/wf/mig_cons/README.md
+++ b/mig/wf/mig_cons/README.md
@@ -9,7 +9,7 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../../BACKUP/](../../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../../bk_temp/](../../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../../../backup/](../../../backup/)
 
 ## 3. Crossref y Mapping
@@ -38,9 +38,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../../../legacy/](../../../legacy/) o [../../../tmp_staging/](../../../tmp_staging/)
 2. **Staging / MIG:** [../../](../../)
 3. **Consolidación / CORE:** [../../../core/](../../../core/)
-4. **Backup / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../BACKUP/](../../../BACKUP/)
+4. **bk_temp / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../bk_temp/](../../../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/mig/wf/relv/README_bucket_template - copia.md
+++ b/mig/wf/relv/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/mig/wf/tareas_acciones/README_bucket_template - copia.md
+++ b/mig/wf/tareas_acciones/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/packages/README.md
+++ b/packages/README.md
@@ -9,12 +9,12 @@
 Paquetes reutilizables y librerías.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../BACKUP/](../BACKUP/)
+- Carpeta de snapshots relacionada: [../bk_temp/](../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../backup/](../backup/)
 
 ## 3. Crossref y Mapping
 - **Referencia ascendente:** `[../]`
-- **Referencias laterales:** [../.git/], [../.pytest_cache/], [../BACKUP/], [../__pycache__/], [../apps/], [../backup/], [../connectors/], [../core/], [../infra/], [../legacy/], [../legacy_old/], [../log/], [../mig/], [../scripts/], [../tmp_staging/]
+- **Referencias laterales:** [../.git/], [../.pytest_cache/], [../bk_temp/], [../__pycache__/], [../apps/], [../backup/], [../connectors/], [../core/], [../infra/], [../legacy/], [../legacy_old/], [../log/], [../mig/], [../scripts/], [../tmp_staging/]
 - **Buckets destino típicos:** `[../DESTINO/]`
 - **Crossref central:** [Mapa Global](../core/data/crossref_mapping_buckets_aingz_platform_v_1_20250731.md)
 - **Flujos/Pipelines relevantes:** [../infra/pipelines/README.md](../infra/pipelines/README.md)
@@ -36,9 +36,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../legacy/](../legacy/) o [../tmp_staging/](../tmp_staging/)
 2. **Staging / MIG:** [../mig/](../mig/)
 3. **Consolidación / CORE:** [../core/](../core/)
-4. **Backup / Eliminación:** [../backup/](../backup/) y/o [../BACKUP/](../BACKUP/)
+4. **bk_temp / Eliminación:** [../backup/](../backup/) y/o [../bk_temp/](../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/scripts/audit_naming.py
+++ b/scripts/audit_naming.py
@@ -3,7 +3,7 @@ import re
 import sys
 from pathlib import Path
 
-PIPELINE_STAGES = {"LEGACY", "TMP", "MIG", "CORE", "BACKUP"}
+PIPELINE_STAGES = {"LEGACY", "TMP", "MIG", "CORE", "bk_temp"}
 ALLOWED_FILES = {"README.md", "LICENSE", ".gitignore", ".gitattributes", ".editorconfig"}
 SNAKE_RE = re.compile(r"^[a-z0-9_]+(?:\.[a-z0-9_]+)?$")
 EXCLUDE_DIRS = {".git", "legacy_old"}

--- a/tmp_staging/README.md
+++ b/tmp_staging/README.md
@@ -9,12 +9,12 @@
 Zona de staging temporal para validaciones.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../BACKUP/](../BACKUP/)
+- Carpeta de snapshots relacionada: [../bk_temp/](../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../backup/](../backup/)
 
 ## 3. Crossref y Mapping
 - **Referencia ascendente:** `[../]`
-- **Referencias laterales:** [../.git/], [../.pytest_cache/], [../BACKUP/], [../__pycache__/], [../apps/], [../backup/], [../connectors/], [../core/], [../infra/], [../legacy/], [../legacy_old/], [../log/], [../mig/], [../packages/], [../scripts/]
+- **Referencias laterales:** [../.git/], [../.pytest_cache/], [../bk_temp/], [../__pycache__/], [../apps/], [../backup/], [../connectors/], [../core/], [../infra/], [../legacy/], [../legacy_old/], [../log/], [../mig/], [../packages/], [../scripts/]
 - **Buckets destino típicos:** `[../DESTINO/]`
 - **Crossref central:** [Mapa Global](../core/data/crossref_mapping_buckets_aingz_platform_v_1_20250731.md)
 - **Flujos/Pipelines relevantes:** [../infra/pipelines/README.md](../infra/pipelines/README.md)
@@ -41,10 +41,10 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../legacy/](../legacy/) o [./](./)
 2. **Staging / MIG:** [../mig/](../mig/)
 3. **Consolidación / CORE:** [../core/](../core/)
-4. **Backup / Eliminación:** [../backup/](../backup/) y/o [../BACKUP/](../BACKUP/)
+4. **bk_temp / Eliminación:** [../backup/](../backup/) y/o [../bk_temp/](../bk_temp/)
 
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/tmp_staging/data/README.md
+++ b/tmp_staging/data/README.md
@@ -9,7 +9,7 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../BACKUP/](../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../bk_temp/](../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../../backup/](../../backup/)
 
 ## 3. Crossref y Mapping
@@ -40,9 +40,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../../legacy/](../../legacy/) o [../](../)
 2. **Staging / MIG:** [../../mig/](../../mig/)
 3. **Consolidación / CORE:** [../../core/](../../core/)
-4. **Backup / Eliminación:** [../../backup/](../../backup/) y/o [../../BACKUP/](../../BACKUP/)
+4. **bk_temp / Eliminación:** [../../backup/](../../backup/) y/o [../../bk_temp/](../../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/tmp_staging/data/arch_research_core_rw_b_v_1.md
+++ b/tmp_staging/data/arch_research_core_rw_b_v_1.md
@@ -26,7 +26,7 @@ Repo Root /
 │   ├── DATA/              # Bibliotecas internas, datasets, recursos técnicos
 │   ├── AUDIT/             # Resultados de auditoría interna, QA, logs extendidos
 │   ├── RESEARCH/          # Research interna, benchmarks, papers, deep docs
-│   ├── BACKUP/            # Snapshots/versiones internas validadas
+│   ├── bk_temp/            # Snapshots/versiones internas validadas
 │   ├── PURG/              # Activos en staging previo a purga/migración
 └── MIG/                   # Outputs temporales de migración/consolidación
 ```
@@ -39,7 +39,7 @@ Repo Root /
 2. Validación/Auditoría → `MAIN/AUDIT/`
 3. Consolidación/activo → `MAIN/ASSETS/`
 4. Research avanzado → `MAIN/RESEARCH/`
-5. Backup periódico → `MAIN/BACKUP/`
+5. Backup periódico → `MAIN/bk_temp/`
 6. Purga/Migración → `MAIN/PURG/` o `MIG/`
 
 ---
@@ -60,7 +60,7 @@ Repo Root /
 - **MAIN/DATA/**: Bibliotecas internas, datasets, recursos crudos/procesados.
 - **MAIN/AUDIT/**: Informes QA, validaciones, logs extendidos.
 - **MAIN/RESEARCH/**: Research profundo, papers, benchmarks internos.
-- **MAIN/BACKUP/**: Snapshots internos, restauraciones.
+- **MAIN/bk_temp/**: Snapshots internos, restauraciones.
 - **MAIN/PURG/**: Staging para activos antes de migración o purga.
 - **MIG/**: Outputs de migración/consolidación, staging para integración definitiva.
 

--- a/tmp_staging/data/barrido_literal_redefinicion_legacy.md
+++ b/tmp_staging/data/barrido_literal_redefinicion_legacy.md
@@ -59,7 +59,7 @@
 - **Workflow visible:**
   - Indicar pasos para curaduría, triggers y responsables.
 - **Tags/estado:**
-  - `STA=PENDING` hasta migrar; luego `STA=ACTV/BACKUP/PURG` según ciclo.
+  - `STA=PENDING` hasta migrar; luego `STA=ACTV/bk_temp/PURG` según ciclo.
 
 ---
 

--- a/tmp_staging/data/dir_arch_plan_v_5_integracion_matrix.md
+++ b/tmp_staging/data/dir_arch_plan_v_5_integracion_matrix.md
@@ -25,7 +25,7 @@ Repo Root /
 ├── DATA/                  # Matrices, datasets, CSV/Parquet
 ├── LOG/                   # Logs, changelogs, bitácoras (E01)
 │   └── AUDT/              # Audit logs pesados (E06)
-├── BACKUP/                # Snapshots y BLN (B13)
+├── bk_temp/                # Snapshots y BLN (B13)
 │   └── 🟩 INT/             # 🟩 Backups internos (Matrix)
 │   └── 🟩 EXT_OFF/         # 🟩 Backups externos oficiales
 │   └── 🟩 EXT_COM/         # 🟩 Backups comunidad externa
@@ -57,10 +57,10 @@ Repo Root /
 | R09   | `/DATA`              | INT/EXT | AC    | REF  | Datasets, matrices, etc.            | -               |
 | R10   | `/LOG`               | INT     | AC    | LOG  | Logs generales                      | -               |
 | R11   | `/LOG/AUDT`          | INT     | AU    | LOG  | Logs de auditoría pesada            | -               |
-| R12   | `/BACKUP/int`        | INT     | BK    | CORE | Snapshots internos                  | 🟩 split Matrix |
-| 🟩R13 | `/BACKUP/ext_off`    | EXT-OFF | BK    | CORE | Snapshots externos oficiales        | 🟩 nuevo        |
-| 🟩R14 | `/BACKUP/ext_com`    | EXT-COM | BK    | REF  | Snapshots comunidad externa         | 🟩 nuevo        |
-| 🟩R15 | `/BACKUP/ai`         | AI      | BK    | TL   | Snapshots/backup outputs IA         | 🟩 nuevo        |
+| R12   | `/bk_temp/int`        | INT     | BK    | CORE | Snapshots internos                  | 🟩 split Matrix |
+| 🟩R13 | `/bk_temp/ext_off`    | EXT-OFF | BK    | CORE | Snapshots externos oficiales        | 🟩 nuevo        |
+| 🟩R14 | `/bk_temp/ext_com`    | EXT-COM | BK    | REF  | Snapshots comunidad externa         | 🟩 nuevo        |
+| 🟩R15 | `/bk_temp/ai`         | AI      | BK    | TL   | Snapshots/backup outputs IA         | 🟩 nuevo        |
 | R16   | `/PURGATORIO/LEGACY` | INT-LEG | PG    | CORE | Purgatorio legacy interno           | -               |
 | 🟩R17 | `/PURGATORIO/ai`     | AI      | PG    | TL   | Purgatorio IA                       | 🟩 nuevo        |
 | R18   | `/TMP`               | INT/AI  | DR    | TL   | Archivos temporales y drafts        | -               |
@@ -81,7 +81,7 @@ Repo Root /
 
 ## 4. Diferencias clave v5 vs v4
 
-- 🟩 Buckets nuevos: `/KNS/ext_com`, `/KNS/ext_off`, `/BACKUP/ext_com`, `/BACKUP/ext_off`, `/BACKUP/ai`, `/PURGATORIO/ai`, `/TMP/ai`, `/CORE/int_leg`.
+- 🟩 Buckets nuevos: `/KNS/ext_com`, `/KNS/ext_off`, `/bk_temp/ext_com`, `/bk_temp/ext_off`, `/bk_temp/ai`, `/PURGATORIO/ai`, `/TMP/ai`, `/CORE/int_leg`.
 - 🟩 Tabla de buckets ahora referencia explícita a combinaciones Matrix y procedimiento.
 - 🟩 Flujos de integración IA y training comunitario referenciados en triggers y workflows.
 - 🟩 Naming reforzado y obligatorio con código Matrix en toda la infraestructura.

--- a/tmp_staging/data/mplan/README.md
+++ b/tmp_staging/data/mplan/README.md
@@ -9,7 +9,7 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../../BACKUP/](../../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../../bk_temp/](../../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../../../backup/](../../../backup/)
 
 ## 3. Crossref y Mapping
@@ -38,9 +38,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../../../legacy/](../../../legacy/) o [../../](../../)
 2. **Staging / MIG:** [../../../mig/](../../../mig/)
 3. **Consolidación / CORE:** [../../../core/](../../../core/)
-4. **Backup / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../BACKUP/](../../../BACKUP/)
+4. **bk_temp / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../bk_temp/](../../../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/tmp_staging/data/mtx/README.md
+++ b/tmp_staging/data/mtx/README.md
@@ -9,7 +9,7 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../../BACKUP/](../../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../../bk_temp/](../../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../../../backup/](../../../backup/)
 
 ## 3. Crossref y Mapping
@@ -38,9 +38,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../../../legacy/](../../../legacy/) o [../../](../../)
 2. **Staging / MIG:** [../../../mig/](../../../mig/)
 3. **Consolidación / CORE:** [../../../core/](../../../core/)
-4. **Backup / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../BACKUP/](../../../BACKUP/)
+4. **bk_temp / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../bk_temp/](../../../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/tmp_staging/data/politica_cierre_eliminacion_purgatorio.md
+++ b/tmp_staging/data/politica_cierre_eliminacion_purgatorio.md
@@ -7,7 +7,7 @@
 - No se acumulan ni mantienen archivos basura, obsoletos o redundantes.
 - Todo activo en desarrollo, tras ser consolidado y migrado, **no deja restos pendientes**:
   - Lo útil/valioso se integra al core.
-  - Si es externo (PDF, libro, doc oficial), se respalda comprimido en BACKUP.
+  - Si es externo (PDF, libro, doc oficial), se respalda comprimido en bk_temp.
   - Lo descartado se elimina físicamente.
 
 ---
@@ -19,14 +19,14 @@
    - La referencia a archivos “superados” es inválida.
 2. **Eliminación directa post-consolidación:**
    - Si es propio, versión vieja se elimina tras merge y logging.
-   - Si es externo, se comprime y archiva en BACKUP.
+   - Si es externo, se comprime y archiva en bk_temp.
    - Lo que no se necesita, se elimina de forma permanente.
 3. **Control por workflow y checklist:**
    - El workflow y QA validan que tras la consolidación **no quedan residuos en staging** ni archivos en “limbo”.
    - El backup solo contiene lo estrictamente necesario.
 4. **Sin purgatorio, sin zona gris:**
    - Cada activo pasa por:  
-     LEGACY → STAGING/DESARROLLO → CONSOLIDADO/ACTIVO → (si aplica) BACKUP → Eliminación.
+     LEGACY → STAGING/DESARROLLO → CONSOLIDADO/ACTIVO → (si aplica) bk_temp → Eliminación.
    - No existen buckets de archivos “a decidir después”.
 
 ---

--- a/tmp_staging/data/rulset/README.md
+++ b/tmp_staging/data/rulset/README.md
@@ -9,7 +9,7 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../../BACKUP/](../../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../../bk_temp/](../../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../../../backup/](../../../backup/)
 
 ## 3. Crossref y Mapping
@@ -38,9 +38,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../../../legacy/](../../../legacy/) o [../../](../../)
 2. **Staging / MIG:** [../../../mig/](../../../mig/)
 3. **Consolidación / CORE:** [../../../core/](../../../core/)
-4. **Backup / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../BACKUP/](../../../BACKUP/)
+4. **bk_temp / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../bk_temp/](../../../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/tmp_staging/data/rw_b_dir_arch_plan_v_4_20250729.md
+++ b/tmp_staging/data/rw_b_dir_arch_plan_v_4_20250729.md
@@ -33,7 +33,7 @@ Repo Root /
 ├── DATA/                  # Matrices, datasets, CSV/Parquet
 ├── LOG/                   # Logs, changelogs, bitácoras (E01)
 │   └── AUDT/              # Audit logs pesados (E06)
-├── BACKUP/                # Snapshots y BLN (B13)
+├── bk_temp/                # Snapshots y BLN (B13)
 ├── PURGATORIO/            # Obsoletos/legacy (B15)
 │   └── LEGACY/            # Activos antiguos/externos para migración
 ├── TMP/                   # Temp files, scratchpads, procesamiento previo consolidación
@@ -56,7 +56,7 @@ Repo Root /
 | R08 | `/DATA`              | CORE      | MTR       | Matrices, datasets, CSV/Parquet.                                            | H01             |
 | R09 | `/LOG`               | CORE      | LOG       | Logs, changelogs, bitácoras.                                                | E01             |
 | R10 | `/LOG/AUDT`          | AU        | ADT       | Audit logs detallados (pesados).                                            | E06             |
-| R11 | `/BACKUP`            | BK        | BK        | Snapshots BLN y backups comprimidos.                                        | B13             |
+| R11 | `/bk_temp`            | BK        | BK        | Snapshots BLN y backups comprimidos.                                        | B13             |
 | R12 | `/PURGATORIO`        | PG        | PURG      | Stage de obsoletos antes de eliminación o migración legacy.                 | B15             |
 | R13 | `/PURGATORIO/LEGACY` | LG        | LEGACY    | Activos antiguos/externos para migración.                                   | LEGACY          |
 | R14 | `/TMP`               | TEMP      | TMP       | Archivos temporales y scratchpad de dictado/auditoría.                      | TMP             |
@@ -93,7 +93,7 @@ Repo Root /
 3. Consolidado/manual mapping → `/DOC` o `/KNS`
 4. Migración literal → `/MIG`
 5. Auditoría final → `/LOG/AUDT`
-6. Si se archiva, pasa a `/PURGATORIO` o `/BACKUP`
+6. Si se archiva, pasa a `/PURGATORIO` o `/bk_temp`
 
 ---
 

--- a/tmp_staging/data/template/README.md
+++ b/tmp_staging/data/template/README.md
@@ -9,7 +9,7 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../../BACKUP/](../../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../../bk_temp/](../../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../../../backup/](../../../backup/)
 
 ## 3. Crossref y Mapping
@@ -38,9 +38,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../../../legacy/](../../../legacy/) o [../../](../../)
 2. **Staging / MIG:** [../../../mig/](../../../mig/)
 3. **Consolidación / CORE:** [../../../core/](../../../core/)
-4. **Backup / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../BACKUP/](../../../BACKUP/)
+4. **bk_temp / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../bk_temp/](../../../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/tmp_staging/doc/README_bucket_template - copia.md
+++ b/tmp_staging/doc/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/tmp_staging/doc/audio/README.md
+++ b/tmp_staging/doc/audio/README.md
@@ -9,7 +9,7 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../../BACKUP/](../../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../../bk_temp/](../../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../../../backup/](../../../backup/)
 
 ## 3. Crossref y Mapping
@@ -38,9 +38,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../../../legacy/](../../../legacy/) o [../../](../../)
 2. **Staging / MIG:** [../../../mig/](../../../mig/)
 3. **Consolidación / CORE:** [../../../core/](../../../core/)
-4. **Backup / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../BACKUP/](../../../BACKUP/)
+4. **bk_temp / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../bk_temp/](../../../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/tmp_staging/doc/image/README_bucket_template - copia.md
+++ b/tmp_staging/doc/image/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/tmp_staging/doc/library/README.md
+++ b/tmp_staging/doc/library/README.md
@@ -9,7 +9,7 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../../BACKUP/](../../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../../bk_temp/](../../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../../../backup/](../../../backup/)
 
 ## 3. Crossref y Mapping
@@ -38,9 +38,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../../../legacy/](../../../legacy/) o [../../](../../)
 2. **Staging / MIG:** [../../../mig/](../../../mig/)
 3. **Consolidación / CORE:** [../../../core/](../../../core/)
-4. **Backup / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../BACKUP/](../../../BACKUP/)
+4. **bk_temp / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../bk_temp/](../../../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/tmp_staging/doc/library_ext/README.md
+++ b/tmp_staging/doc/library_ext/README.md
@@ -9,7 +9,7 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../../BACKUP/](../../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../../bk_temp/](../../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../../../backup/](../../../backup/)
 
 ## 3. Crossref y Mapping
@@ -38,9 +38,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../../../legacy/](../../../legacy/) o [../../](../../)
 2. **Staging / MIG:** [../../../mig/](../../../mig/)
 3. **Consolidación / CORE:** [../../../core/](../../../core/)
-4. **Backup / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../BACKUP/](../../../BACKUP/)
+4. **bk_temp / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../bk_temp/](../../../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/tmp_staging/doc/onbrd/README.md
+++ b/tmp_staging/doc/onbrd/README.md
@@ -9,7 +9,7 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../../BACKUP/](../../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../../bk_temp/](../../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../../../backup/](../../../backup/)
 
 ## 3. Crossref y Mapping
@@ -38,9 +38,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../../../legacy/](../../../legacy/) o [../../](../../)
 2. **Staging / MIG:** [../../../mig/](../../../mig/)
 3. **Consolidación / CORE:** [../../../core/](../../../core/)
-4. **Backup / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../BACKUP/](../../../BACKUP/)
+4. **bk_temp / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../bk_temp/](../../../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/tmp_staging/doc/template/README.md
+++ b/tmp_staging/doc/template/README.md
@@ -9,7 +9,7 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../../BACKUP/](../../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../../bk_temp/](../../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../../../backup/](../../../backup/)
 
 ## 3. Crossref y Mapping
@@ -38,9 +38,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../../../legacy/](../../../legacy/) o [../../](../../)
 2. **Staging / MIG:** [../../../mig/](../../../mig/)
 3. **Consolidación / CORE:** [../../../core/](../../../core/)
-4. **Backup / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../BACKUP/](../../../BACKUP/)
+4. **bk_temp / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../bk_temp/](../../../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/tmp_staging/doc/video/README.md
+++ b/tmp_staging/doc/video/README.md
@@ -9,7 +9,7 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../../BACKUP/](../../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../../bk_temp/](../../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../../../backup/](../../../backup/)
 
 ## 3. Crossref y Mapping
@@ -38,9 +38,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../../../legacy/](../../../legacy/) o [../../](../../)
 2. **Staging / MIG:** [../../../mig/](../../../mig/)
 3. **Consolidación / CORE:** [../../../core/](../../../core/)
-4. **Backup / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../BACKUP/](../../../BACKUP/)
+4. **bk_temp / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../bk_temp/](../../../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/tmp_staging/kns/README_bucket_template - copia.md
+++ b/tmp_staging/kns/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/tmp_staging/kns/ai_learn/README_bucket_template - copia.md
+++ b/tmp_staging/kns/ai_learn/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/tmp_staging/kns/ai_learn/eval/README_bucket_template - copia.md
+++ b/tmp_staging/kns/ai_learn/eval/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/tmp_staging/kns/ai_learn/feed/README_bucket_template - copia.md
+++ b/tmp_staging/kns/ai_learn/feed/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/tmp_staging/kns/ai_learn/learn/README_bucket_template - copia.md
+++ b/tmp_staging/kns/ai_learn/learn/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/tmp_staging/kns/ai_learn/rel/README_bucket_template - copia.md
+++ b/tmp_staging/kns/ai_learn/rel/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/tmp_staging/kns/ai_learn/shot/README_bucket_template - copia.md
+++ b/tmp_staging/kns/ai_learn/shot/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/tmp_staging/kns/ai_learn/trn/README_bucket_template - copia.md
+++ b/tmp_staging/kns/ai_learn/trn/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/tmp_staging/kns/ai_learn/tune/README_bucket_template - copia.md
+++ b/tmp_staging/kns/ai_learn/tune/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/tmp_staging/kns/chkp/README_bucket_template - copia.md
+++ b/tmp_staging/kns/chkp/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/tmp_staging/kns/chkp/aingz_platform/README_bucket_template - copia.md
+++ b/tmp_staging/kns/chkp/aingz_platform/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/tmp_staging/kns/chkp/projects/README_bucket_template - copia.md
+++ b/tmp_staging/kns/chkp/projects/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/tmp_staging/kns/ctx/README_bucket_template - copia.md
+++ b/tmp_staging/kns/ctx/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/tmp_staging/kns/ctx/aingz_platform/README_bucket_template - copia.md
+++ b/tmp_staging/kns/ctx/aingz_platform/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/tmp_staging/kns/ctx/projects/README_bucket_template - copia.md
+++ b/tmp_staging/kns/ctx/projects/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/tmp_staging/kns/ctx/snaphots_ai/README_bucket_template - copia.md
+++ b/tmp_staging/kns/ctx/snaphots_ai/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/tmp_staging/log/README_bucket_template - copia.md
+++ b/tmp_staging/log/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/tmp_staging/log/bitacoras/README_bucket_template - copia.md
+++ b/tmp_staging/log/bitacoras/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/tmp_staging/log/changelog/README_bucket_template - copia.md
+++ b/tmp_staging/log/changelog/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/tmp_staging/log/trazabilidad_total/README_bucket_template - copia.md
+++ b/tmp_staging/log/trazabilidad_total/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/tmp_staging/scr/README_bucket_template - copia.md
+++ b/tmp_staging/scr/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/tmp_staging/wf/README_bucket_template - copia.md
+++ b/tmp_staging/wf/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/tmp_staging/wf/audt/README.md
+++ b/tmp_staging/wf/audt/README.md
@@ -9,7 +9,7 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../../BACKUP/](../../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../../bk_temp/](../../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../../../backup/](../../../backup/)
 
 ## 3. Crossref y Mapping
@@ -38,9 +38,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../../../legacy/](../../../legacy/) o [../../](../../)
 2. **Staging / MIG:** [../../../mig/](../../../mig/)
 3. **Consolidación / CORE:** [../../../core/](../../../core/)
-4. **Backup / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../BACKUP/](../../../BACKUP/)
+4. **bk_temp / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../bk_temp/](../../../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/tmp_staging/wf/mig_cons/README.md
+++ b/tmp_staging/wf/mig_cons/README.md
@@ -9,7 +9,7 @@
 Descripción pendiente.
 
 ## 2. Snapshots / Contexto
-- Carpeta de snapshots relacionada: [../../../BACKUP/](../../../BACKUP/)
+- Carpeta de snapshots relacionada: [../../../bk_temp/](../../../bk_temp/)
 - Enlaces a versiones relevantes o backups IA: [../../../backup/](../../../backup/)
 
 ## 3. Crossref y Mapping
@@ -38,9 +38,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** [../../../legacy/](../../../legacy/) o [../../](../../)
 2. **Staging / MIG:** [../../../mig/](../../../mig/)
 3. **Consolidación / CORE:** [../../../core/](../../../core/)
-4. **Backup / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../BACKUP/](../../../BACKUP/)
+4. **bk_temp / Eliminación:** [../../../backup/](../../../backup/) y/o [../../../bk_temp/](../../../bk_temp/)
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/tmp_staging/wf/relv/README_bucket_template - copia.md
+++ b/tmp_staging/wf/relv/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 

--- a/tmp_staging/wf/tareas_acciones/README_bucket_template - copia.md
+++ b/tmp_staging/wf/tareas_acciones/README_bucket_template - copia.md
@@ -32,9 +32,9 @@ Describe los pasos clave del ciclo de vida para los archivos de este bucket:
 1. **Ingreso / LEGACY o TMP:** `[../WF/wf_ingreso_BUCKET.md]`
 2. **Staging / MIG:** `[../WF/wf_staging_BUCKET.md]`
 3. **Consolidación / CORE:** `[../WF/wf_consolidacion_BUCKET.md]`
-4. **Backup / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
+4. **bk_temp / Eliminación:** `[../WF/wf_backup_BUCKET.md]`
 
-Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→BACKUP`.
+Ajustar enlaces de acuerdo al pipeline oficial y etapas de `LEGACY→TMP→MIG→CORE→bk_temp`.
 
 ---
 


### PR DESCRIPTION
## Summary
- replace deprecated BACKUP folder with bk_temp
- document lifecycle updates in backup staging and temp folders
- extend audit script to allow bk_temp stage

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e6f25cb2883298d3a46afd538f16a