### PR TITLE
chore: ignore venv and refine naming audit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ logs/
 *.tmp
 *.temp
 *.swp
+
+# Ignore virtual environments
+venv/

--- a/scripts/audit_naming.py
+++ b/scripts/audit_naming.py
@@ -6,7 +6,7 @@ from pathlib import Path
 PIPELINE_STAGES = {"LEGACY", "TMP", "MIG", "CORE", "bk_temp"}
 ALLOWED_FILES = {"README.md", "LICENSE", ".gitignore", ".gitattributes", ".editorconfig"}
 SNAKE_RE = re.compile(r"^[a-z0-9_]+(?:\.[a-z0-9_]+)?$")
-EXCLUDE_DIRS = {".git", "legacy_old"}
+EXCLUDE_DIRS = {".git", "legacy_old", "venv", "SNAPSHOTS_CTX"}
 
 def main() -> None:
     root = Path(__file__).resolve().parent.parent


### PR DESCRIPTION
## Summary
- ignore local virtual environments in git
- extend naming audit exclusions for venv and SNAPSHOTS_CTX directories

## Testing
- `pip install -r requirements.txt`
- `python scripts/audit_naming.py`
- `python scripts/check_glossary_refs.py`
- `python scripts/report_kpis.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ec0d23c8c8329b38d42f9d70308f5