### PR TITLE
Add YAML headers and audit for v4 ops docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+---
+version: "1.0"
+status: "updated"
+crossref: "core/data/crossref_mapping_buckets_aingz_platform_v_1_20250731.md"
+---
+
 # AingZ_Platform_main — README v1
 
 > **STATUS:** `UPDATED`

--- a/platform_v_4_0/main/ops/log/ops_log_readme_v_4_0.md
+++ b/platform_v_4_0/main/ops/log/ops_log_readme_v_4_0.md
@@ -1,8 +1,10 @@
 ---
+version: "4.0"
+status: "draft"
+crossref: "../../../../core/data/crossref_mapping_buckets_aingz_platform_v_1_20250731.md"
+---
 
-## file: README.md version: v3.1-2025-08-05 bucket: ops/log blueprint: ../../../blueprint\_rw\_b\_platform\_v\_3\_20250803.md status: active updated: 2025-08-05 role: documentation owner: AingZ\_Platform · RwB
-
-# [RwB] ops/log/ — README (v3.1)
+# [RwB] ops/log/ — README (v4.0)
 
 > **Tagline:** Carpeta de logs y bitácoras operativas, registros automáticos/manuales y trazabilidad de todos los procesos críticos.
 

--- a/platform_v_4_0/main/ops/ops_readme_v_4_0.md
+++ b/platform_v_4_0/main/ops/ops_readme_v_4_0.md
@@ -1,15 +1,11 @@
 ---
-file: README.md
-version: v3.1-2025-08-05
-bucket: ops
-blueprint: ../../blueprint_rw_b_platform_v_3_20250803.md
-status: active
-updated: 2025-08-05
-role: documentation
-owner: AingZ_Platform · RwB
+version: "4.0"
+status: "draft"
+crossref: "../../../core/data/crossref_mapping_buckets_aingz_platform_v_1_20250731.md"
 ---
 
-# [RwB] ops/ — README (v3.1)
+
+# [RwB] ops/ — README (v4.0)
 
 > **Tagline:** Orquestador operativo: scripts, pipelines, testing, logs y plantillas para automatización y soporte de la plataforma.
 

--- a/platform_v_4_0/main/ops/pipelines/ops_pipelines_readme_v_4_0.md
+++ b/platform_v_4_0/main/ops/pipelines/ops_pipelines_readme_v_4_0.md
@@ -1,8 +1,10 @@
 ---
+version: "4.0"
+status: "draft"
+crossref: "../../../../core/data/crossref_mapping_buckets_aingz_platform_v_1_20250731.md"
+---
 
-## file: README.md version: v3.1-2025-08-05 bucket: ops/pipelines blueprint: ../../../blueprint\_rw\_b\_platform\_v\_3\_20250803.md status: active updated: 2025-08-05 role: documentation owner: AingZ\_Platform · RwB
-
-# [RwB] ops/pipelines/ — README (v3.1)
+# [RwB] ops/pipelines/ — README (v4.0)
 
 > **Tagline:** Definición y gestión de pipelines automáticos: CI/CD, onboarding, validación y testing para todos los buckets de la plataforma.
 

--- a/platform_v_4_0/main/ops/scr/audit_paths_v_4_0.py
+++ b/platform_v_4_0/main/ops/scr/audit_paths_v_4_0.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+import pathlib
+import sys
+
+BASE = pathlib.Path(__file__).resolve().parents[1]
+
+def main():
+    mismatched = []
+    for md in BASE.rglob('*.md'):
+        if 'v_4_0' not in md.name:
+            mismatched.append(str(md.relative_to(BASE)))
+    if mismatched:
+        print('Files without v_4_0 naming:')
+        for m in mismatched:
+            print('-', m)
+        sys.exit(1)
+    print('All ops markdown files follow v_4_0 naming convention.')
+
+if __name__ == '__main__':
+    main()

--- a/platform_v_4_0/main/ops/scr/ops_scripts_readme_v_4_0.md
+++ b/platform_v_4_0/main/ops/scr/ops_scripts_readme_v_4_0.md
@@ -1,8 +1,10 @@
 ---
+version: "4.0"
+status: "draft"
+crossref: "../../../../core/data/crossref_mapping_buckets_aingz_platform_v_1_20250731.md"
+---
 
-## file: README.md version: v3.1-2025-08-05 bucket: ops/scripts blueprint: ../../../blueprint\_rw\_b\_platform\_v\_3\_20250803.md status: active updated: 2025-08-05 role: documentation owner: AingZ\_Platform · RwB
-
-# [RwB] ops/scripts/ — README (v3.1)
+# [RwB] ops/scripts/ — README (v4.0)
 
 > **Tagline:** Scripts automáticos de soporte, mantenimiento, procesamiento y utilidades para toda la plataforma.
 

--- a/platform_v_4_0/main/ops/templates/template_readme_rw_b_v_4_0.md
+++ b/platform_v_4_0/main/ops/templates/template_readme_rw_b_v_4_0.md
@@ -1,21 +1,16 @@
 ---
+version: "4.0"
+status: "draft"
+crossref: "../../../../core/data/crossref_mapping_buckets_aingz_platform_v_1_20250731.md"
+---
 
-file: template\_readme\_rw\_b\_v3\_1.md version: v3.1-2025-08-06 status: template role: readme owner: AingZ\_Platform · RwB crossref:
-
-- blueprint\_rw\_b\_platform\_v\_3\_20250803.md
-- mpln\_master\_plan\_rw\_b\_v\_3\_20250803.md
-- checklist\_root\_rw\_b\_v\_3\_20250805.md
-- wf\_pipeline\_creacion\_archivos\_rw\_b\_v\_3\_20250805.md
-- rw\_b\_glosario\_code\_v\_2\_20250729.md
-- rw\_b\_diccionario\_code\_triggers\_v\_2\_20250729.md
-- ops/templates/template\_readme\_rw\_b\_v3\_1.md  # Ruta y referencia definitiva en ops/templates changelog:
-- 2025-08-06: Creación del template universal README v3.1 (alineado blueprint/master plan)
+- 2025-08-06: Creación del template universal README v4.0 (alineado blueprint/master plan)
 - 2025-08-06: Update — descripción extendida, objetivos, sistemas relacionados, contexto humano/IA.
 - 2025-08-06: Ruta definitiva confirmada → ops/templates/
 
 ---
 
-# 📘 [RwB] README Universal — v3.1
+# 📘 [RwB] README Universal — v4.0
 
 ## 1. Descripción, función, objetivos y contexto
 
@@ -60,5 +55,5 @@ done
 
 ---
 
-**FIN TEMPLATE UNIVERSAL README v3.1 (ops/templates, versión activa)**
+**FIN TEMPLATE UNIVERSAL README v4.0 (ops/templates, versión activa)**
 

--- a/platform_v_4_0/main/ops/test/ops_test_readme_v_4_0.md
+++ b/platform_v_4_0/main/ops/test/ops_test_readme_v_4_0.md
@@ -1,8 +1,10 @@
 ---
+version: "4.0"
+status: "draft"
+crossref: "../../../../core/data/crossref_mapping_buckets_aingz_platform_v_1_20250731.md"
+---
 
-## file: README.md version: v3.1-2025-08-05 bucket: ops/test blueprint: ../../../blueprint\_rw\_b\_platform\_v\_3\_20250803.md status: active updated: 2025-08-05 role: documentation owner: AingZ\_Platform · RwB
-
-# [RwB] ops/test/ — README (v3.1)
+# [RwB] ops/test/ — README (v4.0)
 
 > **Tagline:** Testing y QA automatizado para cada asset, workflow y pipeline; matriz de pruebas y logs de resultados.
 


### PR DESCRIPTION
## Summary
- add YAML front matter to root and ops documentation with version, status and cross references
- rename ops documentation files to v4.0 naming and update headings
- introduce audit script checking ops markdown naming convention

## Testing
- `python platform_v_4_0/main/ops/scr/audit_paths_v_4_0.py`


------
https://chatgpt.com/codex/tasks/task_e_68949dac65f08329b796bdd7f04705a8