### PR TITLE
Add baseline Codex V4 script and log

### DIFF
--- a/ops/log/baseline_codex_v4.log
+++ b/ops/log/baseline_codex_v4.log
@@ -1,0 +1,687 @@
+[
+  {
+    "folder": ".",
+    "files": [
+      {
+        "name": "README.md",
+        "version": null,
+        "has_yaml": false
+      },
+      {
+        "name": "prompt_codex_baseline_v_4_check.md",
+        "version": null,
+        "has_yaml": false
+      },
+      {
+        "name": "rw_b_blueprint_v_4_extendido_2025_08_06.md",
+        "version": null,
+        "has_yaml": false
+      },
+      {
+        "name": "rw_b_master_plan_v_4_extendido_2025_08_06.md",
+        "version": null,
+        "has_yaml": false
+      }
+    ]
+  },
+  {
+    "folder": "core",
+    "files": [
+      {
+        "name": "README.md",
+        "version": null,
+        "has_yaml": true
+      }
+    ]
+  },
+  {
+    "folder": "core/data",
+    "files": [
+      {
+        "name": "README.md",
+        "version": null,
+        "has_yaml": true
+      }
+    ]
+  },
+  {
+    "folder": "core/data/rulset",
+    "files": [
+      {
+        "name": "README.md",
+        "version": null,
+        "has_yaml": true
+      }
+    ]
+  },
+  {
+    "folder": "core/data/mplan",
+    "files": [
+      {
+        "name": "README.md",
+        "version": null,
+        "has_yaml": true
+      }
+    ]
+  },
+  {
+    "folder": "core/data/mtx",
+    "files": [
+      {
+        "name": "README.md",
+        "version": null,
+        "has_yaml": true
+      }
+    ]
+  },
+  {
+    "folder": "core/data/template",
+    "files": [
+      {
+        "name": "README.md",
+        "version": null,
+        "has_yaml": true
+      }
+    ]
+  },
+  {
+    "folder": "core/data/dicts",
+    "files": [
+      {
+        "name": "README.md",
+        "version": null,
+        "has_yaml": true
+      },
+      {
+        "name": "rw_b_diccionario_code_triggers_v_2_20250729.md",
+        "version": null,
+        "has_yaml": false
+      }
+    ]
+  },
+  {
+    "folder": "core/wf",
+    "files": [
+      {
+        "name": "README.md",
+        "version": null,
+        "has_yaml": true
+      }
+    ]
+  },
+  {
+    "folder": "core/doc",
+    "files": [
+      {
+        "name": "README.md",
+        "version": null,
+        "has_yaml": true
+      }
+    ]
+  },
+  {
+    "folder": "core/doc/image",
+    "files": [
+      {
+        "name": "README.md",
+        "version": null,
+        "has_yaml": true
+      }
+    ]
+  },
+  {
+    "folder": "core/doc/video",
+    "files": [
+      {
+        "name": "README.md",
+        "version": null,
+        "has_yaml": true
+      }
+    ]
+  },
+  {
+    "folder": "core/doc/template",
+    "files": [
+      {
+        "name": "README.md",
+        "version": null,
+        "has_yaml": true
+      }
+    ]
+  },
+  {
+    "folder": "core/doc/audio",
+    "files": [
+      {
+        "name": "README.md",
+        "version": null,
+        "has_yaml": true
+      }
+    ]
+  },
+  {
+    "folder": "core/doc/onbrd",
+    "files": [
+      {
+        "name": "README.md",
+        "version": null,
+        "has_yaml": true
+      }
+    ]
+  },
+  {
+    "folder": "core/kns",
+    "files": [
+      {
+        "name": "README.md",
+        "version": null,
+        "has_yaml": true
+      }
+    ]
+  },
+  {
+    "folder": "core/kns/metrics",
+    "files": [
+      {
+        "name": "readme_core_kns_metrics_rw_b_v_3_2.md",
+        "version": null,
+        "has_yaml": false
+      }
+    ]
+  },
+  {
+    "folder": "core/kns/ai_learn",
+    "files": [
+      {
+        "name": "readme_core_kns_ai_learn_rw_b_v_3_2.md",
+        "version": null,
+        "has_yaml": false
+      }
+    ]
+  },
+  {
+    "folder": "core/kns/ai_learn/trn",
+    "files": [
+      {
+        "name": "readme_core_kns_ai_learn_trn_rw_b_v_3_2.md",
+        "version": null,
+        "has_yaml": false
+      }
+    ]
+  },
+  {
+    "folder": "core/kns/ai_learn/eval",
+    "files": [
+      {
+        "name": "readme_core_kns_ai_learn_eval_rw_b_v_3_2.md",
+        "version": null,
+        "has_yaml": false
+      }
+    ]
+  },
+  {
+    "folder": "core/kns/ai_learn/feed",
+    "files": [
+      {
+        "name": "readme_core_kns_ai_learn_feed_rw_b_v_3_2.md",
+        "version": null,
+        "has_yaml": false
+      }
+    ]
+  },
+  {
+    "folder": "core/kns/ai_learn/rel",
+    "files": [
+      {
+        "name": "readme_core_kns_ai_learn_rel_rw_b_v_3_2.md",
+        "version": null,
+        "has_yaml": false
+      }
+    ]
+  },
+  {
+    "folder": "core/kns/ai_learn/insi",
+    "files": [
+      {
+        "name": "readme_core_kns_ai_learn_insi_rw_b_v_3_2.md",
+        "version": null,
+        "has_yaml": false
+      }
+    ]
+  },
+  {
+    "folder": "core/kns/ai_learn/tune",
+    "files": [
+      {
+        "name": "readme_core_kns_ai_learn_tune_rw_b_v_3_2.md",
+        "version": null,
+        "has_yaml": false
+      }
+    ]
+  },
+  {
+    "folder": "core/kns/ai_learn/shot",
+    "files": [
+      {
+        "name": "readme_core_kns_ai_learn_shot_rw_b_v_3_2.md",
+        "version": null,
+        "has_yaml": false
+      }
+    ]
+  },
+  {
+    "folder": "core/kns/ai_learn/learn",
+    "files": [
+      {
+        "name": "readme_core_kns_ai_learn_learn_rw_b_v_3_2.md",
+        "version": null,
+        "has_yaml": false
+      }
+    ]
+  },
+  {
+    "folder": "core/kns/ctx",
+    "files": [
+      {
+        "name": "readme_core_kns_ctx_rw_b_v_3_2.md",
+        "version": null,
+        "has_yaml": false
+      }
+    ]
+  },
+  {
+    "folder": "core/kns/ctx/projects",
+    "files": [
+      {
+        "name": "readme_core_kns_ctx_projects_rw_b_v_3_2.md",
+        "version": null,
+        "has_yaml": false
+      }
+    ]
+  },
+  {
+    "folder": "core/kns/ctx/aingz_platform",
+    "files": [
+      {
+        "name": "readme_core_kns_ctx_aingz_platform_rw_b_v_3_2.md",
+        "version": null,
+        "has_yaml": false
+      }
+    ]
+  },
+  {
+    "folder": "core/kns/glossary",
+    "files": [
+      {
+        "name": "readme_core_kns_glossary_rw_b_v_3_2.md",
+        "version": null,
+        "has_yaml": false
+      },
+      {
+        "name": "rw_b_glosario_code_v_2_20250729.md",
+        "version": null,
+        "has_yaml": false
+      }
+    ]
+  },
+  {
+    "folder": "core/kns/triggers",
+    "files": [
+      {
+        "name": "readme_core_kns_triggers_rw_b_v_3_2.md",
+        "version": null,
+        "has_yaml": false
+      },
+      {
+        "name": "rw_b_diccionario_code_triggers_v_2_20250729.md",
+        "version": null,
+        "has_yaml": false
+      }
+    ]
+  },
+  {
+    "folder": "core/kns/chkp",
+    "files": [
+      {
+        "name": "readme_core_kns_chkp_rw_b_v_3_2.md",
+        "version": null,
+        "has_yaml": false
+      }
+    ]
+  },
+  {
+    "folder": "core/kns/chkp/projects",
+    "files": [
+      {
+        "name": "readme_core_kns_chkp_projects_rw_b_v_3_2.md",
+        "version": null,
+        "has_yaml": false
+      }
+    ]
+  },
+  {
+    "folder": "core/kns/chkp/aingz_platform",
+    "files": [
+      {
+        "name": "readme_core_kns_chkp_aingz_platform_rw_b_v_3_2.md",
+        "version": null,
+        "has_yaml": false
+      }
+    ]
+  },
+  {
+    "folder": "core/kns/ideas_brainstorm",
+    "files": [
+      {
+        "name": "readme_core_kns_ideas_brainstorm_rw_b_v_3_2.md",
+        "version": null,
+        "has_yaml": false
+      }
+    ]
+  },
+  {
+    "folder": "library",
+    "files": [
+      {
+        "name": "readme_library_rw_b_v_3_1.md",
+        "version": null,
+        "has_yaml": true
+      }
+    ]
+  },
+  {
+    "folder": "library/normas",
+    "files": [
+      {
+        "name": "readme_library_normas_rw_b_v_3_1.md",
+        "version": null,
+        "has_yaml": true
+      }
+    ]
+  },
+  {
+    "folder": "library/datasets",
+    "files": [
+      {
+        "name": "readme_library_datasets_rw_b_v_3_1.md",
+        "version": null,
+        "has_yaml": true
+      }
+    ]
+  },
+  {
+    "folder": "library/papers",
+    "files": [
+      {
+        "name": "readme_library_papers_rw_b_v_3_1.md",
+        "version": null,
+        "has_yaml": true
+      }
+    ]
+  },
+  {
+    "folder": "library/books",
+    "files": [
+      {
+        "name": "readme_library_books_rw_b_v_3_1.md",
+        "version": null,
+        "has_yaml": true
+      }
+    ]
+  },
+  {
+    "folder": "library/licencias",
+    "files": [
+      {
+        "name": "readme_library_licencias_rw_b_v_3_1.md",
+        "version": null,
+        "has_yaml": true
+      }
+    ]
+  },
+  {
+    "folder": "library/manuals",
+    "files": [
+      {
+        "name": "readme_library_manuals_rw_b_v_3_1.md",
+        "version": null,
+        "has_yaml": true
+      }
+    ]
+  },
+  {
+    "folder": "lifecycle",
+    "files": [
+      {
+        "name": "lifecycle_readme_v_3_1.md",
+        "version": null,
+        "has_yaml": false
+      }
+    ]
+  },
+  {
+    "folder": "lifecycle/temp",
+    "files": [
+      {
+        "name": "lifecycle_temp_readme_v_3_1.md",
+        "version": null,
+        "has_yaml": true
+      }
+    ]
+  },
+  {
+    "folder": "lifecycle/mig",
+    "files": [
+      {
+        "name": "lifecycle_mig_readme_v_3_1.md",
+        "version": null,
+        "has_yaml": false
+      }
+    ]
+  },
+  {
+    "folder": "lifecycle/bk_temp",
+    "files": [
+      {
+        "name": "lifecycle_bk_temp_readme_v_3_1.md",
+        "version": null,
+        "has_yaml": false
+      }
+    ]
+  },
+  {
+    "folder": "lifecycle/legacy",
+    "files": [
+      {
+        "name": "lifecycle_legacy_readme_v_3_1.md",
+        "version": null,
+        "has_yaml": false
+      }
+    ]
+  },
+  {
+    "folder": "ops",
+    "files": [
+      {
+        "name": "ops_readme_v_4_0.md",
+        "version": null,
+        "has_yaml": true
+      }
+    ]
+  },
+  {
+    "folder": "ops/pipelines",
+    "files": [
+      {
+        "name": "ops_pipelines_readme_v_4_0.md",
+        "version": null,
+        "has_yaml": true
+      }
+    ]
+  },
+  {
+    "folder": "ops/log",
+    "files": [
+      {
+        "name": "ops_log_readme_v_4_0.md",
+        "version": null,
+        "has_yaml": true
+      }
+    ]
+  },
+  {
+    "folder": "ops/templates",
+    "files": [
+      {
+        "name": "template_readme_rw_b_v_4_0.md",
+        "version": null,
+        "has_yaml": true
+      }
+    ]
+  },
+  {
+    "folder": "ops/test",
+    "files": [
+      {
+        "name": "ops_test_readme_v_4_0.md",
+        "version": null,
+        "has_yaml": true
+      }
+    ]
+  },
+  {
+    "folder": "ops/scr",
+    "files": [
+      {
+        "name": "audit_paths_v_4_0.py",
+        "version": null,
+        "has_yaml": false
+      },
+      {
+        "name": "ops_scripts_readme_v_4_0.md",
+        "version": null,
+        "has_yaml": true
+      }
+    ]
+  },
+  {
+    "folder": "snapshots_ctx",
+    "files": [
+      {
+        "name": "snapshots_ctx_readme_v_3_1.md",
+        "version": null,
+        "has_yaml": false
+      }
+    ]
+  },
+  {
+    "folder": "snapshots_ctx/common",
+    "files": [
+      {
+        "name": "snapshots_ctx_common_readme_v_3_1.md",
+        "version": null,
+        "has_yaml": false
+      }
+    ]
+  },
+  {
+    "folder": "snapshots_ctx/gpt_4_1",
+    "files": [
+      {
+        "name": "snapshots_ctx_gpt_4_1_readme_v_3_1.md",
+        "version": null,
+        "has_yaml": false
+      }
+    ]
+  },
+  {
+    "folder": "snapshots_ctx/gpt_4o",
+    "files": [
+      {
+        "name": "snapshots_ctx_gpt_4_o_readme_v_3_1.md",
+        "version": null,
+        "has_yaml": false
+      }
+    ]
+  },
+  {
+    "folder": "snapshots_ctx/codex",
+    "files": [
+      {
+        "name": "snapshots_ctx_codex_readme_v_3_1.md",
+        "version": null,
+        "has_yaml": false
+      }
+    ]
+  },
+  {
+    "folder": "snapshots_ctx/gpt_o3",
+    "files": [
+      {
+        "name": "snapshots_ctx_gpt_o_3_readme_v_3_1.md",
+        "version": null,
+        "has_yaml": false
+      }
+    ]
+  },
+  {
+    "folder": "packages",
+    "files": [
+      {
+        "name": "packages_readme_v_3_1.md",
+        "version": null,
+        "has_yaml": false
+      }
+    ]
+  },
+  {
+    "folder": "packages/vds_core",
+    "files": [
+      {
+        "name": "vds_core_readme_v_3_1.md",
+        "version": null,
+        "has_yaml": true
+      }
+    ]
+  },
+  {
+    "folder": "packages/vds_core/plugins",
+    "files": [
+      {
+        "name": "vds_core_plugins_readme_v_3_1.md",
+        "version": null,
+        "has_yaml": false
+      }
+    ]
+  },
+  {
+    "folder": "packages/vds_core/tests",
+    "files": [
+      {
+        "name": "vds_core_tests_readme_v_3_1.md",
+        "version": null,
+        "has_yaml": false
+      }
+    ]
+  },
+  {
+    "folder": "packages/vds_core/templates",
+    "files": [
+      {
+        "name": "vds_core_templates_readme_v_3_1.md",
+        "version": null,
+        "has_yaml": false
+      }
+    ]
+  },
+  {
+    "folder": "packages/vds_core/onboarding",
+    "files": [
+      {
+        "name": "vds_core_onboarding_readme_v_3_1.md",
+        "version": null,
+        "has_yaml": false
+      }
+    ]
+  }
+]

--- a/ops/scripts/README.md
+++ b/ops/scripts/README.md
@@ -1,0 +1,21 @@
+# Ops Scripts
+
+This directory contains operational scripts for AingZ Platform.
+
+## baseline_codex_v4.py
+
+Generates a baseline report for `platform_v_4_0/main`.
+
+### Usage
+
+```bash
+python ops/scripts/baseline_codex_v4.py [--root PATH] [--format json|yaml] [--log PATH]
+```
+
+### Parameters
+
+- `--root`: Repository root path. Defaults to project root.
+- `--format`: Output format (`json` or `yaml`). Defaults to `json`.
+- `--log`: Destination log file. Defaults to `ops/log/baseline_codex_v4.log`.
+
+The script prints the baseline to stdout and writes the same content to the log file.

--- a/ops/scripts/baseline_codex_v4.py
+++ b/ops/scripts/baseline_codex_v4.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Generate baseline for platform_v_4_0/main.
+
+Derived from instructions in platform_v_4_0/main/prompt_codex_baseline_v_4_check.md
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, List
+
+import yaml
+
+
+def parse_file_metadata(file_path: Path) -> Dict[str, Any]:
+    """Return metadata about a file.
+
+    Parameters
+    ----------
+    file_path: Path
+        File to inspect for YAML front matter.
+
+    Returns
+    -------
+    dict with keys: name, version, has_yaml
+    """
+    info: Dict[str, Any] = {"name": file_path.name, "version": None, "has_yaml": False}
+    try:
+        with file_path.open("r", encoding="utf-8") as fh:
+            first_line = fh.readline().strip()
+            if first_line == "---":
+                yaml_lines: List[str] = []
+                for line in fh:
+                    if line.strip() == "---":
+                        break
+                    yaml_lines.append(line)
+                meta = yaml.safe_load("".join(yaml_lines)) or {}
+                info["has_yaml"] = True
+                info["version"] = meta.get("VERSION")
+    except Exception:
+        # Ignore unreadable files
+        pass
+    return info
+
+
+def collect_baseline(root: Path) -> List[Dict[str, Any]]:
+    """Traverse platform_v_4_0/main and collect metadata."""
+    base_path = root / "platform_v_4_0" / "main"
+    results: List[Dict[str, Any]] = []
+    for folder, _dirs, files in os.walk(base_path):
+        folder_path = Path(folder)
+        rel_folder = folder_path.relative_to(base_path)
+        file_infos = [parse_file_metadata(folder_path / f) for f in sorted(files)]
+        results.append({"folder": str(rel_folder), "files": file_infos})
+    return results
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Baseline Codex V4")
+    parser.add_argument(
+        "--root",
+        default=str(Path(__file__).resolve().parents[2]),
+        help="Repository root path",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["json", "yaml"],
+        default="json",
+        help="Output serialization format",
+    )
+    parser.add_argument(
+        "--log",
+        default="ops/log/baseline_codex_v4.log",
+        help="Path to log file",
+    )
+    args = parser.parse_args()
+
+    root_path = Path(args.root)
+    data = collect_baseline(root_path)
+
+    if args.format == "yaml":
+        output = yaml.safe_dump(data, sort_keys=False, allow_unicode=True)
+    else:
+        output = json.dumps(data, indent=2, ensure_ascii=False)
+
+    print(output)
+
+    log_path = root_path / args.log
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    log_path.write_text(output, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `baseline_codex_v4.py` to traverse `platform_v_4_0/main` and log metadata
- document script usage in `ops/scripts/README.md`
- generate `ops/log/baseline_codex_v4.log` with current baseline snapshot

## Testing
- `python ops/scripts/baseline_codex_v4.py --format json`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894ca5f650483299e97662d6de2bb4c