### PR TITLE
docs: remover referencias a core/kns/audit

### DIFF
--- a/core/kns/readme_core_kns_rw_b_v_3_2.md
+++ b/core/kns/readme_core_kns_rw_b_v_3_2.md
@@ -66,6 +66,7 @@ graph TD;
 ## 5. Changelog local
 
 - 2025-08-06: Versión v3.2, integración de glosario y triggers vivos, ajuste compliance.
+- 2025-08-07: Deprecado submódulo `audit/`; scripts y reportes migrados a `ops/`.
 
 ## 6. Observaciones / Lessons learned
 

--- a/ops/log/ops_log_readme_v_3_1.md
+++ b/ops/log/ops_log_readme_v_3_1.md
@@ -99,6 +99,7 @@ $ cat chglog_main_rwb_v_5_*.md
 | Fecha      | Versión | Autor       | Cambios                      |
 | ---------- | ------- | ----------- | ---------------------------- |
 | 2025-08-05 | v3.1    | ChatGPT 4.1 | README inicial log/ enriched |
+| 2025-08-07 | v3.1    | ChatGPT 4.1 | Migración de `audit/` desde `core/kns/`; reporte en `ops/log/` |
 
 ---
 

--- a/prompt_codex_baseline_v_4_check.md
+++ b/prompt_codex_baseline_v_4_check.md
@@ -52,7 +52,7 @@ Toda acción que realices debe respetar la **Regla de Máxima Jerarquía**: *Nam
 
 ### 2. Diagnóstico & clasificación
 
-2.1 Clasifica cada discrepancia: `MISSING`, `RENAME`, `LEGACY`, `DUPLICATE`, `INVALID_ROUTE`. 2.2 Genera reporte `diagnosis.md` en `core/kns/audit/` con tablas resumen y enlaces a cada ítem.
+2.1 Clasifica cada discrepancia: `MISSING`, `RENAME`, `LEGACY`, `DUPLICATE`, `INVALID_ROUTE`. 2.2 Genera reporte `diagnosis_baseline.md` en `ops/log/` con tablas resumen y enlaces a cada ítem.
 
 ### 3. Creación / corrección de estructura
 
@@ -69,7 +69,7 @@ Toda acción que realices debe respetar la **Regla de Máxima Jerarquía**: *Nam
 ### 6. Entregables
 
 - `baseline.csv` · snapshot BLN ✔️
-- `diagnosis.md` · reporte auditoría ✔️
+- `diagnosis_baseline.md` · reporte auditoría ✔️
 - Folders & README creados/actualizados ✔️
 - `CHANGELOG`, `LESSONS_LEARNED`, `CHECKLIST` incrementados ✔️
 - Log de triggers ejecutados (`valog.log`) ✔️
@@ -83,7 +83,7 @@ LOT_ID: <datetime‑ISO>
 SUMMARY: "Folders creados: X | READMEs actualizados: Y | Legacy movidos: Z"
 DETAILS:
   BASELINE: baseline.csv
-  REPORT: core/kns/audit/diagnosis.md
+  REPORT: ops/log/diagnosis_baseline.md
   CHANGELOG: core/log/changelog.md
   CHECKLIST: core/log/checklist.md
   LESSONS_LEARNED: core/kns/lessons_learned.md


### PR DESCRIPTION
## Summary
- actualiza prompt de auditoría para usar `ops/log/diagnosis_baseline.md`
- registra la migración de `core/kns/audit` a `ops/` en los changelogs de `kns` y `ops/log`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895258445f083299b90d486fc8f6a03