### PR TITLE
Add crossref updater and refresh README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@
 ## 3. Crossref dinámico y referencia clave
 - Todos los scripts y README **deben detectar automáticamente** la ruta actual de:
   - `Prompt_Codex_Baseline_V4_Check.md`
-  - `rw_b_blueprint_v_4_extendido_2025_08_06.md`
-  - `rw_b_master_plan_v_4_extendido_2025_08_06.md`
+  - `lifecycle/temp/rw_b_blueprint_v_4_extendido_2025_08_06.md`
+  - `lifecycle/temp/rw_b_master_plan_v_4_extendido_2025_08_06.md`
   - Cualquier README clave y ruleset (`RULE_CODING_COMPLIANCE_V4.md`)
 - Al detectar cambios de ubicación:
   - **Actualizar crossref en todos los README afectados**

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,8 @@
+- Updated crossref in README.md: rw_b_blueprint_v_4_extendido_2025_08_06.md -> lifecycle/temp/rw_b_blueprint_v_4_extendido_2025_08_06.md
+- Updated crossref in README.md: rw_b_master_plan_v_4_extendido_2025_08_06.md -> lifecycle/temp/rw_b_master_plan_v_4_extendido_2025_08_06.md
+- Updated crossref in ops/ops_readme_v_3_1.md: rw_b_blueprint_v_4_extendido_2025_08_06.md -> lifecycle/temp/rw_b_blueprint_v_4_extendido_2025_08_06.md
+- Updated crossref in ops/ops_readme_v_3_1.md: rw_b_master_plan_v_4_extendido_2025_08_06.md -> lifecycle/temp/rw_b_master_plan_v_4_extendido_2025_08_06.md
+- Updated crossref in ops/scripts/ops_scripts_readme_v_3_1.md: rw_b_blueprint_v_4_extendido_2025_08_06.md -> lifecycle/temp/rw_b_blueprint_v_4_extendido_2025_08_06.md
+- Updated crossref in ops/scripts/ops_scripts_readme_v_3_1.md: rw_b_master_plan_v_4_extendido_2025_08_06.md -> lifecycle/temp/rw_b_master_plan_v_4_extendido_2025_08_06.md
+- Updated crossref in ops/log/ops_log_readme_v_3_1.md: rw_b_blueprint_v_4_extendido_2025_08_06.md -> lifecycle/temp/rw_b_blueprint_v_4_extendido_2025_08_06.md
+- Updated crossref in ops/log/ops_log_readme_v_3_1.md: rw_b_master_plan_v_4_extendido_2025_08_06.md -> lifecycle/temp/rw_b_master_plan_v_4_extendido_2025_08_06.md

--- a/lessons_learned.md
+++ b/lessons_learned.md
@@ -1,0 +1,8 @@
+- Updated crossref in README.md: rw_b_blueprint_v_4_extendido_2025_08_06.md -> lifecycle/temp/rw_b_blueprint_v_4_extendido_2025_08_06.md
+- Updated crossref in README.md: rw_b_master_plan_v_4_extendido_2025_08_06.md -> lifecycle/temp/rw_b_master_plan_v_4_extendido_2025_08_06.md
+- Updated crossref in ops/ops_readme_v_3_1.md: rw_b_blueprint_v_4_extendido_2025_08_06.md -> lifecycle/temp/rw_b_blueprint_v_4_extendido_2025_08_06.md
+- Updated crossref in ops/ops_readme_v_3_1.md: rw_b_master_plan_v_4_extendido_2025_08_06.md -> lifecycle/temp/rw_b_master_plan_v_4_extendido_2025_08_06.md
+- Updated crossref in ops/scripts/ops_scripts_readme_v_3_1.md: rw_b_blueprint_v_4_extendido_2025_08_06.md -> lifecycle/temp/rw_b_blueprint_v_4_extendido_2025_08_06.md
+- Updated crossref in ops/scripts/ops_scripts_readme_v_3_1.md: rw_b_master_plan_v_4_extendido_2025_08_06.md -> lifecycle/temp/rw_b_master_plan_v_4_extendido_2025_08_06.md
+- Updated crossref in ops/log/ops_log_readme_v_3_1.md: rw_b_blueprint_v_4_extendido_2025_08_06.md -> lifecycle/temp/rw_b_blueprint_v_4_extendido_2025_08_06.md
+- Updated crossref in ops/log/ops_log_readme_v_3_1.md: rw_b_master_plan_v_4_extendido_2025_08_06.md -> lifecycle/temp/rw_b_master_plan_v_4_extendido_2025_08_06.md

--- a/ops/log/ops_log_readme_v_3_1.md
+++ b/ops/log/ops_log_readme_v_3_1.md
@@ -1,6 +1,6 @@
 ---
 
-## file: README.md version: v3.1-2025-08-05 bucket: ops/log blueprint: ../../rw_b_blueprint_v_4_extendido_2025_08_06.md status: active updated: 2025-08-05 role: documentation owner: AingZ_Platform · RwB
+## file: README.md version: v3.1-2025-08-05 bucket: ops/log blueprint: ../../lifecycle/temp/rw_b_blueprint_v_4_extendido_2025_08_06.md status: active updated: 2025-08-05 role: documentation owner: AingZ_Platform · RwB
 
 # [RwB] ops/log/ — README (v3.1)
 
@@ -46,8 +46,8 @@ Directorio para todos los logs, bitácoras y registros cronológicos generados p
 
 ## 3. Cross‑References
 
-- **Blueprint v4** → [`../../rw_b_blueprint_v_4_extendido_2025_08_06.md`](../../rw_b_blueprint_v_4_extendido_2025_08_06.md)
-- **Master Plan v4** → [`../../rw_b_master_plan_v_4_extendido_2025_08_06.md`](../../rw_b_master_plan_v_4_extendido_2025_08_06.md)
+- **Blueprint v4** → [`../../lifecycle/temp/rw_b_blueprint_v_4_extendido_2025_08_06.md`](../../lifecycle/temp/rw_b_blueprint_v_4_extendido_2025_08_06.md)
+- **Master Plan v4** → [`../../lifecycle/temp/rw_b_master_plan_v_4_extendido_2025_08_06.md`](../../lifecycle/temp/rw_b_master_plan_v_4_extendido_2025_08_06.md)
 - **Checklist Root v3** → [`../../checklist_root_rw_b_v_3_20250803.md`](../../checklist_root_rw_b_v_3_20250803.md)
 - **Triggers**: `TRG_AUDIT_LEGACY`, `TRG_CONSOLIDATE_TL`, `TRG_PURGE_AI`
 
@@ -109,8 +109,8 @@ $ cat chglog_main_rwb_v_5_*.md
 bucket: ops/log
 version: v3.1
 updated: 2025-08-05
-blueprint_ref: ../../rw_b_blueprint_v_4_extendido_2025_08_06.md
-master_plan_ref: ../../rw_b_master_plan_v_4_extendido_2025_08_06.md
+blueprint_ref: ../../lifecycle/temp/rw_b_blueprint_v_4_extendido_2025_08_06.md
+master_plan_ref: ../../lifecycle/temp/rw_b_master_plan_v_4_extendido_2025_08_06.md
 triggers:
   - TRG_AUDIT_LEGACY
   - TRG_CONSOLIDATE_TL

--- a/ops/ops_readme_v_3_1.md
+++ b/ops/ops_readme_v_3_1.md
@@ -2,7 +2,7 @@
 file: README.md
 version: v3.1-2025-08-05
 bucket: ops
-blueprint: ../rw_b_blueprint_v_4_extendido_2025_08_06.md
+blueprint: ../lifecycle/temp/rw_b_blueprint_v_4_extendido_2025_08_06.md
 status: active
 updated: 2025-08-05
 role: documentation
@@ -51,8 +51,8 @@ El bucket `ops/` centraliza todos los recursos de operación y soporte: scripts,
 
 ## 3. Cross‑References
 
-- **Blueprint v4** → [`rw_b_blueprint_v_4_extendido_2025_08_06.md`](../rw_b_blueprint_v_4_extendido_2025_08_06.md)
-- **Master Plan v4** → [`rw_b_master_plan_v_4_extendido_2025_08_06.md`](../rw_b_master_plan_v_4_extendido_2025_08_06.md)
+- **Blueprint v4** → [`lifecycle/temp/rw_b_blueprint_v_4_extendido_2025_08_06.md`](../lifecycle/temp/rw_b_blueprint_v_4_extendido_2025_08_06.md)
+- **Master Plan v4** → [`lifecycle/temp/rw_b_master_plan_v_4_extendido_2025_08_06.md`](../lifecycle/temp/rw_b_master_plan_v_4_extendido_2025_08_06.md)
 - **Checklist Root v3** → [`checklist_root_rw_b_v_3_20250803.md`](../checklist_root_rw_b_v_3_20250803.md)
 - **Glosario CODE v2** → [`../core/kns/glossary/rw_b_glosario_code_v_2_20250729.md`](../core/kns/glossary/rw_b_glosario_code_v_2_20250729.md)
 - **Diccionario CODE_TRIGGERS v2** → [`../core/data/dicts/rw_b_diccionario_code_triggers_v_2_20250729.md`](../core/data/dicts/rw_b_diccionario_code_triggers_v_2_20250729.md)
@@ -131,8 +131,8 @@ $ bash scripts/<script>.sh
 bucket: ops
 version: v3.1
 updated: 2025-08-05
-blueprint_ref: ../rw_b_blueprint_v_4_extendido_2025_08_06.md
-master_plan_ref: ../rw_b_master_plan_v_4_extendido_2025_08_06.md
+blueprint_ref: ../lifecycle/temp/rw_b_blueprint_v_4_extendido_2025_08_06.md
+master_plan_ref: ../lifecycle/temp/rw_b_master_plan_v_4_extendido_2025_08_06.md
 triggers:
   - TRG_AUDIT_LEGACY
   - TRG_CONSOLIDATE_TL

--- a/ops/scripts/ops_scripts_readme_v_3_1.md
+++ b/ops/scripts/ops_scripts_readme_v_3_1.md
@@ -1,6 +1,6 @@
 ---
 
-## file: README.md version: v3.1-2025-08-05 bucket: ops/scripts blueprint: ../../rw_b_blueprint_v_4_extendido_2025_08_06.md status: active updated: 2025-08-05 role: documentation owner: AingZ_Platform · RwB
+## file: README.md version: v3.1-2025-08-05 bucket: ops/scripts blueprint: ../../lifecycle/temp/rw_b_blueprint_v_4_extendido_2025_08_06.md status: active updated: 2025-08-05 role: documentation owner: AingZ_Platform · RwB
 
 # [RwB] ops/scripts/ — README (v3.1)
 
@@ -48,8 +48,8 @@ Carpeta que centraliza scripts reutilizables para automatización, mantenimiento
 
 ## 3. Cross‑References
 
-- **Blueprint v4** → [`../../rw_b_blueprint_v_4_extendido_2025_08_06.md`](../../rw_b_blueprint_v_4_extendido_2025_08_06.md)
-- **Master Plan v4** → [`../../rw_b_master_plan_v_4_extendido_2025_08_06.md`](../../rw_b_master_plan_v_4_extendido_2025_08_06.md)
+- **Blueprint v4** → [`../../lifecycle/temp/rw_b_blueprint_v_4_extendido_2025_08_06.md`](../../lifecycle/temp/rw_b_blueprint_v_4_extendido_2025_08_06.md)
+- **Master Plan v4** → [`../../lifecycle/temp/rw_b_master_plan_v_4_extendido_2025_08_06.md`](../../lifecycle/temp/rw_b_master_plan_v_4_extendido_2025_08_06.md)
 - **Checklist Root v3** → [`../../checklist_root_rw_b_v_3_20250803.md`](../../checklist_root_rw_b_v_3_20250803.md)
 - **Triggers**: `TRG_AUDIT_LEGACY`, `TRG_CONSOLIDATE_TL`, `TRG_PURGE_AI`
 
@@ -115,8 +115,8 @@ $ python migrate_assets.py
 bucket: ops/scripts
 version: v3.1
 updated: 2025-08-05
-blueprint_ref: ../../rw_b_blueprint_v_4_extendido_2025_08_06.md
-master_plan_ref: ../../rw_b_master_plan_v_4_extendido_2025_08_06.md
+blueprint_ref: ../../lifecycle/temp/rw_b_blueprint_v_4_extendido_2025_08_06.md
+master_plan_ref: ../../lifecycle/temp/rw_b_master_plan_v_4_extendido_2025_08_06.md
 triggers:
   - TRG_AUDIT_LEGACY
   - TRG_CONSOLIDATE_TL

--- a/ops/update_crossrefs.py
+++ b/ops/update_crossrefs.py
@@ -1,0 +1,68 @@
+import json
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+
+def load_paths_cache(cache_path: Path) -> Dict[str, str]:
+    with cache_path.open('r', encoding='utf-8') as f:
+        return json.load(f)
+
+
+def find_readme_files(root: Path) -> List[Path]:
+    files: List[Path] = []
+    for path in root.rglob('*'):
+        if not path.is_file():
+            continue
+        name = path.name.lower()
+        if 'readme' in name and not name.startswith('informe_'):
+            files.append(path)
+    return files
+
+
+def update_file(path: Path, mappings: Dict[str, str]) -> List[Tuple[str, str, str]]:
+    content = path.read_text(encoding='utf-8')
+    original = content
+    updates: List[Tuple[str, str, str]] = []
+
+    for old, new in mappings.items():
+        if not new:
+            continue
+        if old in content and new not in content:
+            content = content.replace(old, new)
+            updates.append((str(path.relative_to(ROOT)), old, new))
+
+    if content != original:
+        path.write_text(content, encoding='utf-8')
+    return updates
+
+
+def log_updates(root: Path, updates: List[Tuple[str, str, str]]) -> None:
+    if not updates:
+        return
+    lines = [f"- Updated crossref in {file}: {old} -> {new}" for file, old, new in updates]
+
+    for log_name in ['changelog.md', 'lessons_learned.md']:
+        log_path = root / log_name
+        existing = ''
+        if log_path.exists():
+            existing = log_path.read_text(encoding='utf-8').rstrip('\n') + '\n'
+        log_path.write_text(existing + '\n'.join(lines) + '\n', encoding='utf-8')
+
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def main() -> None:
+    cache_path = ROOT / 'ops/paths_cache.json'
+    mappings = load_paths_cache(cache_path)
+
+    readmes = find_readme_files(ROOT)
+    all_updates: List[Tuple[str, str, str]] = []
+    for readme in readmes:
+        all_updates.extend(update_file(readme, mappings))
+
+    log_updates(ROOT, all_updates)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add ops/update_crossrefs.py utility to rewrite README cross references from ops/paths_cache.json
- refresh blueprint and master plan links across ops READMEs and root README
- log each crossref change in changelog.md and lessons_learned.md

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'core')*

------
https://chatgpt.com/codex/tasks/task_e_689562117c6083299addfb76130aa701