### PR TITLE
Add coding compliance ruleset and update crossrefs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
   - `Prompt_Codex_Baseline_V4_Check.md`
   - `lifecycle/temp/rw_b_blueprint_v_4_extendido_2025_08_06.md`
   - `lifecycle/temp/rw_b_master_plan_v_4_extendido_2025_08_06.md`
-  - Cualquier README clave y ruleset (`RULE_CODING_COMPLIANCE_V4.md`)
+  - Cualquier README clave y ruleset (`core/rulset/RULE_CODING_COMPLIANCE_V4.md`)
 - Al detectar cambios de ubicación:
   - **Actualizar crossref en todos los README afectados**
   - Registrar cambio en changelog y lessons learned
@@ -59,7 +59,7 @@ version: v4.0-20250807
 crossref_blueprint: (DETECTAR Y ACTUALIZAR RUTA REAL)
 crossref_masterplan: (DETECTAR Y ACTUALIZAR RUTA REAL)
 crossref_prompt_codex: (DETECTAR Y ACTUALIZAR RUTA REAL)
-crossref_ruleset: (DETECTAR Y ACTUALIZAR RUTA REAL)
+crossref_ruleset: core/rulset/RULE_CODING_COMPLIANCE_V4.md
 status: migracion-actualizacion-v4
 note: "Validar crossref dinámico y barrido 100% repo tras cada ciclo."
 ```

--- a/changelog.md
+++ b/changelog.md
@@ -6,3 +6,4 @@
 - Updated crossref in ops/scripts/ops_scripts_readme_v_3_1.md: rw_b_master_plan_v_4_extendido_2025_08_06.md -> lifecycle/temp/rw_b_master_plan_v_4_extendido_2025_08_06.md
 - Updated crossref in ops/log/ops_log_readme_v_3_1.md: rw_b_blueprint_v_4_extendido_2025_08_06.md -> lifecycle/temp/rw_b_blueprint_v_4_extendido_2025_08_06.md
 - Updated crossref in ops/log/ops_log_readme_v_3_1.md: rw_b_master_plan_v_4_extendido_2025_08_06.md -> lifecycle/temp/rw_b_master_plan_v_4_extendido_2025_08_06.md
+- Updated crossref in README.md: RULE_CODING_COMPLIANCE_V4.md -> core/rulset/RULE_CODING_COMPLIANCE_V4.md

--- a/core/rulset/RULE_CODING_COMPLIANCE_V4.md
+++ b/core/rulset/RULE_CODING_COMPLIANCE_V4.md
@@ -1,0 +1,18 @@
+# RULE_CODING_COMPLIANCE_V4 (draft)
+
+## 1. Lineamientos de estilo
+- Adoptar convenciones PEP8 para Python.
+- Incluir docstrings claros en funciones y módulos.
+- Favorecer estructuras modulares y reutilizables.
+- Nombrar commits y ramas siguiendo un formato descriptivo.
+
+## 2. Lineamientos de pruebas
+- Toda nueva funcionalidad debe acompañarse de pruebas `pytest`.
+- Ejecutar `pytest` localmente antes de cada commit.
+- Validar casos edge y comportamiento esperado ante errores.
+
+## 3. Validación dinámica de crossrefs
+- Mantener referencias vivas a archivos críticos en todos los README.
+- Después de mover o crear archivos, correr `python ops/update_crossrefs.py`.
+- Verificar los cambios generados en `README.md`, `changelog.md` y `lessons_learned.md`.
+

--- a/lessons_learned.md
+++ b/lessons_learned.md
@@ -6,3 +6,4 @@
 - Updated crossref in ops/scripts/ops_scripts_readme_v_3_1.md: rw_b_master_plan_v_4_extendido_2025_08_06.md -> lifecycle/temp/rw_b_master_plan_v_4_extendido_2025_08_06.md
 - Updated crossref in ops/log/ops_log_readme_v_3_1.md: rw_b_blueprint_v_4_extendido_2025_08_06.md -> lifecycle/temp/rw_b_blueprint_v_4_extendido_2025_08_06.md
 - Updated crossref in ops/log/ops_log_readme_v_3_1.md: rw_b_master_plan_v_4_extendido_2025_08_06.md -> lifecycle/temp/rw_b_master_plan_v_4_extendido_2025_08_06.md
+- Updated crossref in README.md: RULE_CODING_COMPLIANCE_V4.md -> core/rulset/RULE_CODING_COMPLIANCE_V4.md

--- a/ops/paths_cache.json
+++ b/ops/paths_cache.json
@@ -2,5 +2,5 @@
   "Prompt_Codex_Baseline_V4_Check.md": null,
   "rw_b_blueprint_v_4_extendido_2025_08_06.md": "lifecycle/temp/rw_b_blueprint_v_4_extendido_2025_08_06.md",
   "rw_b_master_plan_v_4_extendido_2025_08_06.md": "lifecycle/temp/rw_b_master_plan_v_4_extendido_2025_08_06.md",
-  "core/rulset/RULE_CODING_COMPLIANCE_V4.md": null
+  "RULE_CODING_COMPLIANCE_V4.md": "core/rulset/RULE_CODING_COMPLIANCE_V4.md"
 }


### PR DESCRIPTION
## Summary
- draft coding compliance ruleset with style, testing, and crossref validation guidance
- link READMEs to ruleset and map path in cache for crossref updates
- log crossref change for traceability

## Testing
- `python ops/update_crossrefs.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'core')*


------
https://chatgpt.com/codex/tasks/task_e_689567c4d7ec8329bf202224fb9506a6