### PR TITLE
Add metadata validation script and update core READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,17 @@
-# [RwB] README.md — Platform ROOT (V4, 2025-08-07, versión reforzada)
-
 ---
+CODE: README_ROOT
+ID: root_readme
+VERSION: v4.0-2025-08-07
+ROUTE: README.md
+CROSSREF:
+  - lifecycle/temp/rw_b_blueprint_v_4_extendido_2025_08_06.md
+  - lifecycle/temp/rw_b_master_plan_v_4_extendido_2025_08_06.md
+  - Prompt_Codex_Baseline_V4_Check.md
+  - core/rulset/RULE_CODING_COMPLIANCE_V4.md
+AUTHOR: AingZ_Platform
+DATE: 2025-08-07
+---
+# [RwB] README.md — Platform ROOT (V4, 2025-08-07, versión reforzada)
 
 ## 1. Estado y advertencia
 *Este README ha sido reforzado para operar bajo arquitectura V4, con instrucciones explícitas para Codex u otros agentes LLM. Debe escanear y actualizar dinámicamente cualquier referencia o crossref afectada por el movimiento de archivos clave.*
@@ -68,3 +79,13 @@ note: "Validar crossref dinámico y barrido 100% repo tras cada ciclo."
 
 **Fin README raíz V4 (con crossref dinámico)**
 
+## OutputTemplate
+```yaml
+CODE:
+ID:
+VERSION:
+ROUTE:
+CROSSREF:
+AUTHOR:
+DATE:
+```

--- a/core/readme_core_rw_b_v_3_2.md
+++ b/core/readme_core_rw_b_v_3_2.md
@@ -1,16 +1,13 @@
 ---
-
-file: readme\_core\_rw\_b\_v3\_2.md version: v3.2-2025-08-06 status: active role: readme owner: AingZ\_Platform · RwB crossref:
-
-- blueprint\_rw\_b\_platform\_v\_3\_20250803.md
-- mpln\_master\_plan\_rw\_b\_v\_3\_20250803.md
-- checklist\_root\_rw\_b\_v\_3\_20250805.md
-- wf\_pipeline\_creacion\_archivos\_rw\_b\_v\_3\_20250805.md
-- rw\_b\_glosario\_code\_v\_2\_20250729.md
-- rw\_b\_diccionario\_code\_triggers\_v\_2\_20250729.md
-- ops/templates/template\_readme\_rw\_b\_v3\_1.md changelog:
-- 2025-08-06: Consolidación árbol y README core v3.2, integración data/dicts, triggers y glosario activos.
-
+CODE: README_CORE
+ID: core_readme
+VERSION: v3.2-2025-08-06
+ROUTE: core/readme_core_rw_b_v_3_2.md
+CROSSREF:
+  - blueprint_rw_b_platform_v_3_20250803.md
+  - mpln_master_plan_rw_b_v_3_20250803.md
+AUTHOR: AingZ_Platform
+DATE: 2025-08-06
 ---
 
 # 🏛️ core/ — Núcleo estructural AingZ/RwB (v3.2)
@@ -76,3 +73,13 @@ graph TD;
 
 **FIN README core/ v3.2 (versión activa)**
 
+## OutputTemplate
+```yaml
+CODE:
+ID:
+VERSION:
+ROUTE:
+CROSSREF:
+AUTHOR:
+DATE:
+```

--- a/ops/validate_metadata.py
+++ b/ops/validate_metadata.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Validate README metadata.
+
+Checks that each provided README file contains a YAML front matter block with
+required fields and ends with an OutputTemplate block.
+"""
+
+import sys
+import re
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    print("pyyaml is required. install with 'pip install pyyaml'")
+    sys.exit(1)
+
+REQUIRED_FIELDS = ["CODE", "ID", "VERSION", "ROUTE", "CROSSREF", "AUTHOR", "DATE"]
+
+
+def extract_front_matter(text: str):
+    if not text.startswith("---"):
+        return None
+    end = text.find("\n---", 3)
+    if end == -1:
+        return None
+    fm_text = text[3:end]
+    try:
+        data = yaml.safe_load(fm_text)
+    except Exception:
+        return None
+    return data
+
+
+def has_output_template(text: str) -> bool:
+    # Look for the heading 'OutputTemplate' near the end of file
+    lines = text.strip().splitlines()
+    return any(line.strip().startswith("## OutputTemplate") for line in lines[-10:])
+
+
+def validate_file(path: Path) -> str:
+    content = path.read_text(encoding="utf-8")
+    data = extract_front_matter(content)
+    if data is None:
+        return f"{path}: missing or malformed YAML front matter"
+    missing = [f for f in REQUIRED_FIELDS if f not in data]
+    if missing:
+        return f"{path}: missing fields {missing}"
+    if not has_output_template(content):
+        return f"{path}: missing OutputTemplate block"
+    return f"{path}: OK"
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python ops/validate_metadata.py <README paths>")
+        sys.exit(1)
+    for arg in sys.argv[1:]:
+        path = Path(arg)
+        if path.exists():
+            print(validate_file(path))
+        else:
+            print(f"{arg}: file not found")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `ops/validate_metadata.py` to check required YAML front matter and OutputTemplate blocks
- insert required metadata and OutputTemplate in `README.md`
- update `core/readme_core_rw_b_v_3_2.md` with standardized metadata

## Testing
- `python ops/validate_metadata.py README.md core/readme_core_rw_b_v_3_2.md`
- `python ops/validate_metadata.py $(find . -iname "readme*.md")` *(fails: missing or malformed YAML front matter in many files)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'core')*


------
https://chatgpt.com/codex/tasks/task_e_68956991a63c8329a2ec8e769f1edc57