### PR TITLE
chore: wire GH token into pipelines and refresh deps

### DIFF
--- a/.github/workflows/baseline_check.yml
+++ b/.github/workflows/baseline_check.yml
@@ -9,8 +9,12 @@ on:
 jobs:
   run-codex-baseline:
     runs-on: ubuntu-latest
+    env:
+      GH_TOKEN_RW_B_CI: ${{ secrets.GH_TOKEN_RW_B_CI }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GH_TOKEN_RW_B_CI }}
       - name: Set up Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,8 +9,12 @@ on:
 jobs:
   run-tests:
     runs-on: ubuntu-latest
+    env:
+      GH_TOKEN_RW_B_CI: ${{ secrets.GH_TOKEN_RW_B_CI }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GH_TOKEN_RW_B_CI }}
       - name: Set up Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -9,8 +9,12 @@ on:
 jobs:
   kpi-report:
     runs-on: ubuntu-latest
+    env:
+      GH_TOKEN_RW_B_CI: ${{ secrets.GH_TOKEN_RW_B_CI }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GH_TOKEN_RW_B_CI }}
       - name: Set up Python
         uses: actions/setup-python@v4
         with:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ wmi; platform_system == "Windows"
 pywin32; platform_system == "Windows"
 pytest
 pytest-cov
+openai
+pyyaml


### PR DESCRIPTION
## Summary
- add `openai` and `pyyaml` to requirements
- use `GH_TOKEN_RW_B_CI` secret for checkout steps across workflows

## Testing
- `pip install -r requirements.txt`
- `pytest` *(fails: ModuleNotFoundError: No module named 'core')*

------
https://chatgpt.com/codex/tasks/task_e_68956eabf4c88329b054fe765c73e594