### PR TITLE
Fix prompt codex crossref path

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ ROUTE: README.md
 CROSSREF:
   - lifecycle/temp/rw_b_blueprint_v_4_extendido_2025_08_06.md
   - lifecycle/temp/rw_b_master_plan_v_4_extendido_2025_08_06.md
-  - Prompt_Codex_Baseline_V4_Check.md
+  - lifecycle/temp/prompt_codex_baseline_v_4_check.md
   - core/rulset/RULE_CODING_COMPLIANCE_V4.md
 AUTHOR: AingZ_Platform
 DATE: 2025-08-07
@@ -27,7 +27,7 @@ DATE: 2025-08-07
 
 ## 3. Crossref dinámico y referencia clave
 - Todos los scripts y README **deben detectar automáticamente** la ruta actual de:
-  - `Prompt_Codex_Baseline_V4_Check.md`
+  - `lifecycle/temp/prompt_codex_baseline_v_4_check.md`
   - `lifecycle/temp/rw_b_blueprint_v_4_extendido_2025_08_06.md`
   - `lifecycle/temp/rw_b_master_plan_v_4_extendido_2025_08_06.md`
   - Cualquier README clave y ruleset (`core/rulset/RULE_CODING_COMPLIANCE_V4.md`)
@@ -69,7 +69,7 @@ file: readme.md
 version: v4.0-20250807
 crossref_blueprint: lifecycle/temp/rw_b_blueprint_v_4_extendido_2025_08_06.md
 crossref_masterplan: lifecycle/temp/rw_b_master_plan_v_4_extendido_2025_08_06.md
-crossref_prompt_codex: null
+crossref_prompt_codex: lifecycle/temp/prompt_codex_baseline_v_4_check.md
 crossref_ruleset: core/rulset/RULE_CODING_COMPLIANCE_V4.md
 status: migracion-actualizacion-v4
 note: "Validar crossref dinámico y barrido 100% repo tras cada ciclo."

--- a/changelog.md
+++ b/changelog.md
@@ -23,3 +23,8 @@ Example entry format:
 - 2025-08-08 | README.md | Updated crossref: crossref_blueprint: (DETECTAR Y ACTUALIZAR RUTA REAL) -> crossref_blueprint: lifecycle/temp/rw_b_blueprint_v_4_extendido_2025_08_06.md
 - 2025-08-08 | README.md | Updated crossref: crossref_masterplan: (DETECTAR Y ACTUALIZAR RUTA REAL) -> crossref_masterplan: lifecycle/temp/rw_b_master_plan_v_4_extendido_2025_08_06.md
 - 2025-08-08 | README.md | Updated crossref: crossref_prompt_codex: (DETECTAR Y ACTUALIZAR RUTA REAL) -> crossref_prompt_codex: null
+- 2025-08-08 | README.md | TRG_AUDIT_TL failed: [Errno 2] No such file or directory: 'TRG_AUDIT_TL'
+- 2025-08-08 | README.md | TRG_CONSOLIDATE_TL failed: [Errno 2] No such file or directory: 'TRG_CONSOLIDATE_TL'
+- 2025-08-08 | README.md | TRG_LSWP failed: [Errno 2] No such file or directory: 'TRG_LSWP'
+- 2025-08-08 | README.md | Updated crossref: Prompt_Codex_Baseline_V4_Check.md -> lifecycle/temp/prompt_codex_baseline_v_4_check.md
+- 2025-08-08 | README.md | Updated crossref: crossref_prompt_codex: null -> crossref_prompt_codex: lifecycle/temp/prompt_codex_baseline_v_4_check.md

--- a/lessons_learned.md
+++ b/lessons_learned.md
@@ -23,3 +23,8 @@ Example entry format:
 - 2025-08-08 | README.md | Updated crossref: crossref_blueprint: (DETECTAR Y ACTUALIZAR RUTA REAL) -> crossref_blueprint: lifecycle/temp/rw_b_blueprint_v_4_extendido_2025_08_06.md
 - 2025-08-08 | README.md | Updated crossref: crossref_masterplan: (DETECTAR Y ACTUALIZAR RUTA REAL) -> crossref_masterplan: lifecycle/temp/rw_b_master_plan_v_4_extendido_2025_08_06.md
 - 2025-08-08 | README.md | Updated crossref: crossref_prompt_codex: (DETECTAR Y ACTUALIZAR RUTA REAL) -> crossref_prompt_codex: null
+- 2025-08-08 | README.md | TRG_AUDIT_TL failed: [Errno 2] No such file or directory: 'TRG_AUDIT_TL'
+- 2025-08-08 | README.md | TRG_CONSOLIDATE_TL failed: [Errno 2] No such file or directory: 'TRG_CONSOLIDATE_TL'
+- 2025-08-08 | README.md | TRG_LSWP failed: [Errno 2] No such file or directory: 'TRG_LSWP'
+- 2025-08-08 | README.md | Updated crossref: Prompt_Codex_Baseline_V4_Check.md -> lifecycle/temp/prompt_codex_baseline_v_4_check.md
+- 2025-08-08 | README.md | Updated crossref: crossref_prompt_codex: null -> crossref_prompt_codex: lifecycle/temp/prompt_codex_baseline_v_4_check.md

--- a/ops/paths_cache.json
+++ b/ops/paths_cache.json
@@ -1,5 +1,5 @@
 {
-  "Prompt_Codex_Baseline_V4_Check.md": null,
+  "Prompt_Codex_Baseline_V4_Check.md": "lifecycle/temp/prompt_codex_baseline_v_4_check.md",
   "rw_b_blueprint_v_4_extendido_2025_08_06.md": "lifecycle/temp/rw_b_blueprint_v_4_extendido_2025_08_06.md",
   "rw_b_master_plan_v_4_extendido_2025_08_06.md": "lifecycle/temp/rw_b_master_plan_v_4_extendido_2025_08_06.md",
   "RULE_CODING_COMPLIANCE_V4.md": "core/rulset/RULE_CODING_COMPLIANCE_V4.md"


### PR DESCRIPTION
## Summary
- point `Prompt_Codex_Baseline_V4_Check.md` to its real location
- propagate `crossref_prompt_codex` across README files
- log crossref update in changelog and lessons learned

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'core')*

------
https://chatgpt.com/codex/tasks/task_e_6895f373abd48329a9ed9134215234e0