### PR TITLE
Update README crossrefs to v4

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -28,3 +28,8 @@ Example entry format:
 - 2025-08-08 | README.md | TRG_LSWP failed: [Errno 2] No such file or directory: 'TRG_LSWP'
 - 2025-08-08 | README.md | Updated crossref: Prompt_Codex_Baseline_V4_Check.md -> lifecycle/temp/prompt_codex_baseline_v_4_check.md
 - 2025-08-08 | README.md | Updated crossref: crossref_prompt_codex: null -> crossref_prompt_codex: lifecycle/temp/prompt_codex_baseline_v_4_check.md
+- 2025-08-08 | core/readme_core_rw_b_v_3_2.md | Updated crossrefs to v4 docs
+- 2025-08-08 | library/readme_library_rw_b_v_3_1.md | Updated crossrefs to v4 docs
+- 2025-08-08 | packages/packages_readme_v_3_1.md | Updated crossrefs to v4 docs
+- 2025-08-08 | packages/vds_core/vds_core_readme_v_3_1.md | Updated crossrefs to v4 docs
+- 2025-08-08 | ops/ops_readme_v_3_1.md | Added prompt codex and ruleset references

--- a/core/readme_core_rw_b_v_3_2.md
+++ b/core/readme_core_rw_b_v_3_2.md
@@ -4,8 +4,10 @@ ID: core_readme
 VERSION: v3.2-2025-08-06
 ROUTE: core/readme_core_rw_b_v_3_2.md
 CROSSREF:
-  - blueprint_rw_b_platform_v_3_20250803.md
-  - mpln_master_plan_rw_b_v_3_20250803.md
+  - lifecycle/temp/rw_b_blueprint_v_4_extendido_2025_08_06.md
+  - lifecycle/temp/rw_b_master_plan_v_4_extendido_2025_08_06.md
+  - lifecycle/temp/prompt_codex_baseline_v_4_check.md
+  - core/rulset/RULE_CODING_COMPLIANCE_V4.md
 AUTHOR: AingZ_Platform
 DATE: 2025-08-06
 ---

--- a/library/readme_library_rw_b_v_3_1.md
+++ b/library/readme_library_rw_b_v_3_1.md
@@ -28,10 +28,12 @@ Bucket para almacenamiento, consulta y versionado de **recursos de referencia**:
 - Versionado semántico y metadatos YAML obligatorios.
 
 ## 4. Crossref obligatoria
-- [Blueprint v3](../../blueprint_rw_b_platform_v_3_20250803.md)
-- [Master Plan v3](../../mpln_master_plan_rw_b_v_3_20250803.md)
-- [Checklist Root](../../checklist_root_rw_b_v_3_20250805.md)
-- [Workflow Naming/Creación](../../wf_pipeline_creacion_archivos_rw_b_v_3_20250805.md)
+- [Blueprint v4](../lifecycle/temp/rw_b_blueprint_v_4_extendido_2025_08_06.md)
+- [Master Plan v4](../lifecycle/temp/rw_b_master_plan_v_4_extendido_2025_08_06.md)
+- [Prompt Codex Baseline v4](../lifecycle/temp/prompt_codex_baseline_v_4_check.md)
+- [Ruleset Coding Compliance v4](../core/rulset/RULE_CODING_COMPLIANCE_V4.md)
+- [Checklist Root](../checklist_root_rw_b_v_3_20250805.md)
+- [Workflow Naming/Creación](../wf_pipeline_creacion_archivos_rw_b_v_3_20250805.md)
 
 ## 5. Flujo y ciclo de vida (PDCA)
 

--- a/ops/ops_readme_v_3_1.md
+++ b/ops/ops_readme_v_3_1.md
@@ -51,8 +51,10 @@ El bucket `ops/` centraliza todos los recursos de operación y soporte: scripts,
 
 ## 3. Cross‑References
 
-- **Blueprint v4** → [`lifecycle/temp/rw_b_blueprint_v_4_extendido_2025_08_06.md`](../lifecycle/temp/rw_b_blueprint_v_4_extendido_2025_08_06.md)
-- **Master Plan v4** → [`lifecycle/temp/rw_b_master_plan_v_4_extendido_2025_08_06.md`](../lifecycle/temp/rw_b_master_plan_v_4_extendido_2025_08_06.md)
+- **Blueprint v4** → [`../lifecycle/temp/rw_b_blueprint_v_4_extendido_2025_08_06.md`](../lifecycle/temp/rw_b_blueprint_v_4_extendido_2025_08_06.md)
+- **Master Plan v4** → [`../lifecycle/temp/rw_b_master_plan_v_4_extendido_2025_08_06.md`](../lifecycle/temp/rw_b_master_plan_v_4_extendido_2025_08_06.md)
+- **Prompt Codex Baseline v4** → [`../lifecycle/temp/prompt_codex_baseline_v_4_check.md`](../lifecycle/temp/prompt_codex_baseline_v_4_check.md)
+- **Ruleset Coding Compliance v4** → [`../core/rulset/RULE_CODING_COMPLIANCE_V4.md`](../core/rulset/RULE_CODING_COMPLIANCE_V4.md)
 - **Checklist Root v3** → [`checklist_root_rw_b_v_3_20250803.md`](../checklist_root_rw_b_v_3_20250803.md)
 - **Glosario CODE v2** → [`../core/kns/glossary/rw_b_glosario_code_v_2_20250729.md`](../core/kns/glossary/rw_b_glosario_code_v_2_20250729.md)
 - **Diccionario CODE_TRIGGERS v2** → [`../core/data/dicts/rw_b_diccionario_code_triggers_v_2_20250729.md`](../core/data/dicts/rw_b_diccionario_code_triggers_v_2_20250729.md)
@@ -133,6 +135,8 @@ version: v3.1
 updated: 2025-08-05
 blueprint_ref: ../lifecycle/temp/rw_b_blueprint_v_4_extendido_2025_08_06.md
 master_plan_ref: ../lifecycle/temp/rw_b_master_plan_v_4_extendido_2025_08_06.md
+prompt_codex_ref: ../lifecycle/temp/prompt_codex_baseline_v_4_check.md
+ruleset_ref: ../core/rulset/RULE_CODING_COMPLIANCE_V4.md
 triggers:
   - TRG_AUDIT_LEGACY
   - TRG_CONSOLIDATE_TL

--- a/packages/packages_readme_v_3_1.md
+++ b/packages/packages_readme_v_3_1.md
@@ -1,6 +1,6 @@
 ---
 
-## file: README.md version: v3.1-2025-08-05 bucket: packages blueprint: ../blueprint\_rw\_b\_platform\_v\_3\_20250803.md status: active updated: 2025-08-05 role: documentation owner: AingZ\_Platform · RwB
+## file: README.md version: v3.1-2025-08-05 bucket: packages blueprint: ../lifecycle/temp/rw_b_blueprint_v_4_extendido_2025_08_06.md status: active updated: 2025-08-05 role: documentation owner: AingZ\_Platform · RwB
 
 # [RwB] packages/ — README (v3.1)
 
@@ -50,8 +50,10 @@ El bucket `packages/` agrupa todos los paquetes funcionales autocontenidos de la
 
 ## 3. Cross‑References
 
-- **Blueprint v3** → [`../blueprint_rw_b_platform_v_3_20250803.md`](../blueprint_rw_b_platform_v_3_20250803.md)
-- **Master Plan v3** → [`../mpln_master_plan_rw_b_v_3_20250803.md`](../mpln_master_plan_rw_b_v_3_20250803.md)
+- **Blueprint v4** → [`../lifecycle/temp/rw_b_blueprint_v_4_extendido_2025_08_06.md`](../lifecycle/temp/rw_b_blueprint_v_4_extendido_2025_08_06.md)
+- **Master Plan v4** → [`../lifecycle/temp/rw_b_master_plan_v_4_extendido_2025_08_06.md`](../lifecycle/temp/rw_b_master_plan_v_4_extendido_2025_08_06.md)
+- **Prompt Codex Baseline v4** → [`../lifecycle/temp/prompt_codex_baseline_v_4_check.md`](../lifecycle/temp/prompt_codex_baseline_v_4_check.md)
+- **Ruleset Coding Compliance v4** → [`../core/rulset/RULE_CODING_COMPLIANCE_V4.md`](../core/rulset/RULE_CODING_COMPLIANCE_V4.md)
 - **Checklist Root v3** → [`../checklist_root_rw_b_v_3_20250803.md`](../checklist_root_rw_b_v_3_20250803.md)
 - **Glosario CODE v2** → [`../core/kns/glossary/rw_b_glosario_code_v_2_20250729.md`](../core/kns/glossary/rw_b_glosario_code_v_2_20250729.md)
 - **Diccionario CODE\_TRIGGERS v2** → [`../core/data/dicts/rw_b_diccionario_code_triggers_v_2_20250729.md`](../core/data/dicts/rw_b_diccionario_code_triggers_v_2_20250729.md)
@@ -122,8 +124,10 @@ $ python main.py
 bucket: packages
 version: v3.1
 updated: 2025-08-05
-blueprint_ref: ../blueprint_rw_b_platform_v_3_20250803.md
-master_plan_ref: ../mpln_master_plan_rw_b_v_3_20250803.md
+blueprint_ref: ../lifecycle/temp/rw_b_blueprint_v_4_extendido_2025_08_06.md
+master_plan_ref: ../lifecycle/temp/rw_b_master_plan_v_4_extendido_2025_08_06.md
+prompt_codex_ref: ../lifecycle/temp/prompt_codex_baseline_v_4_check.md
+ruleset_ref: ../core/rulset/RULE_CODING_COMPLIANCE_V4.md
 triggers:
   - TRG_AUDIT_LEGACY
   - TRG_CONSOLIDATE_TL

--- a/packages/vds_core/vds_core_readme_v_3_1.md
+++ b/packages/vds_core/vds_core_readme_v_3_1.md
@@ -2,7 +2,7 @@
 file: README.md
 version: v3.1-2025-08-05
 bucket: packages/vds_core
-blueprint: ../../blueprint_rw_b_platform_v_3_20250803.md
+blueprint: ../../lifecycle/temp/rw_b_blueprint_v_4_extendido_2025_08_06.md
 status: active
 updated: 2025-08-05
 role: documentation
@@ -52,8 +52,10 @@ Carpeta que implementa el núcleo de la plataforma: lógica central, inicializac
 
 ## 3. Cross‑References
 
-- **Blueprint v3** → [`../../blueprint_rw_b_platform_v_3_20250803.md`](../../blueprint_rw_b_platform_v_3_20250803.md)
-- **Master Plan v3** → [`../../mpln_master_plan_rw_b_v_3_20250803.md`](../../mpln_master_plan_rw_b_v_3_20250803.md)
+- **Blueprint v4** → [`../../lifecycle/temp/rw_b_blueprint_v_4_extendido_2025_08_06.md`](../../lifecycle/temp/rw_b_blueprint_v_4_extendido_2025_08_06.md)
+- **Master Plan v4** → [`../../lifecycle/temp/rw_b_master_plan_v_4_extendido_2025_08_06.md`](../../lifecycle/temp/rw_b_master_plan_v_4_extendido_2025_08_06.md)
+- **Prompt Codex Baseline v4** → [`../../lifecycle/temp/prompt_codex_baseline_v_4_check.md`](../../lifecycle/temp/prompt_codex_baseline_v_4_check.md)
+- **Ruleset Coding Compliance v4** → [`../../core/rulset/RULE_CODING_COMPLIANCE_V4.md`](../../core/rulset/RULE_CODING_COMPLIANCE_V4.md)
 - **Checklist Root v3** → [`../../checklist_root_rw_b_v_3_20250803.md`](../../checklist_root_rw_b_v_3_20250803.md)
 - **Glosario CODE v2** → [`../../core/kns/glossary/rw_b_glosario_code_v_2_20250729.md`](../../core/kns/glossary/rw_b_glosario_code_v_2_20250729.md)
 - **Diccionario CODE_TRIGGERS v2** → [`../../core/data/dicts/rw_b_diccionario_code_triggers_v_2_20250729.md`](../../core/data/dicts/rw_b_diccionario_code_triggers_v_2_20250729.md)
@@ -122,8 +124,10 @@ $ ls tests/
 bucket: packages/vds_core
 version: v3.1
 updated: 2025-08-05
-blueprint_ref: ../../blueprint_rw_b_platform_v_3_20250803.md
-master_plan_ref: ../../mpln_master_plan_rw_b_v_3_20250803.md
+blueprint_ref: ../../lifecycle/temp/rw_b_blueprint_v_4_extendido_2025_08_06.md
+master_plan_ref: ../../lifecycle/temp/rw_b_master_plan_v_4_extendido_2025_08_06.md
+prompt_codex_ref: ../../lifecycle/temp/prompt_codex_baseline_v_4_check.md
+ruleset_ref: ../../core/rulset/RULE_CODING_COMPLIANCE_V4.md
 triggers:
   - TRG_AUDIT_LEGACY
   - TRG_CONSOLIDATE_TL


### PR DESCRIPTION
## Summary
- refresh core, library, packages and ops READMEs with v4 blueprint, master plan, prompt codex and coding compliance references
- document updates in changelog

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'core')*

------
https://chatgpt.com/codex/tasks/task_e_6895f4ef3eb88329a20a3a210aca0460