### PR TITLE
docs: add plan metadata and update ops scripts

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -42,3 +42,8 @@ Example entry format:
 - 2025-08-08 | core/platform_v_4_0.py | Added minimal run entry point
 - 2025-08-08 | ops/scripts/diagnose_baseline.py | Added fallback baseline path
 - 2025-08-08 | ops/baseline.csv | Added configuration example to cover tests
+- 2025-08-08 | ops/paths_cache.json | Added V4 core paths for dynamic crossrefs
+- 2025-08-08 | pln_primeros_pasos_codex_crossref_update_v_4_20250807.md | Added YAML metadata and OutputTemplate
+- 2025-08-08 | ops/scripts/diagnose_baseline.py | Included json config type and ensured all category sections
+- 2025-08-08 | ops/scripts/litw_sweep.py | Executed repository sweep; no missing paths detected
+- 2025-08-08 | README.md & pln_primeros_pasos_codex_crossref_update_v_4_20250807.md | Metadata validated; no issues

--- a/lessons_learned.md
+++ b/lessons_learned.md
@@ -36,3 +36,8 @@ Example entry format:
 - 2025-08-08 | core/platform_v_4_0.py | Simple stubs unblock platform tests
 - 2025-08-08 | ops/scripts/diagnose_baseline.py | Baseline path fallback ensures report generation
 - 2025-08-08 | ops/baseline.csv | Include config files to exercise all categories
+- 2025-08-08 | ops/paths_cache.json | Cache must include core V4 documents for crossref scripts
+- 2025-08-08 | pln_primeros_pasos_codex_crossref_update_v_4_20250807.md | Always start plans with YAML front matter and OutputTemplate
+- 2025-08-08 | ops/scripts/diagnose_baseline.py | Added json config support and default category sections to satisfy tests
+- 2025-08-08 | ops/scripts/litw_sweep.py | Regular sweeps confirm cache completeness
+- 2025-08-08 | ops/validate_metadata.py | Valid metadata blocks prevent crossref drift

--- a/ops/paths_cache.json
+++ b/ops/paths_cache.json
@@ -1,4 +1,8 @@
 [
+  "lifecycle/temp/rw_b_blueprint_v_4_extendido_2025_08_06.md",
+  "lifecycle/temp/rw_b_master_plan_v_4_extendido_2025_08_06.md",
+  "lifecycle/temp/prompt_codex_baseline_v_4_check.md",
+  "core/rulset/RULE_CODING_COMPLIANCE_V4.md",
   "ops/ops_readme_v_3_1.md",
   "ops/pipelines/ops_pipelines_readme_v_3_1.md",
   "ops/test/ops_test_readme_v_3_1.md",

--- a/ops/scripts/diagnose_baseline.py
+++ b/ops/scripts/diagnose_baseline.py
@@ -14,7 +14,7 @@ from typing import Dict, Iterable, List
 
 CODE_EXTS = {"py"}
 DOC_EXTS = {"md"}
-CONFIG_EXTS = {"txt", "ini", "yml", "yaml"}
+CONFIG_EXTS = {"txt", "ini", "yml", "yaml", "json"}
 
 
 def _categorise(ext: str) -> str:
@@ -64,6 +64,8 @@ def main() -> None:
         baseline_path = repo_root / "ops" / "baseline.csv"
     rows = _read_baseline(baseline_path)
     groups = _group_by_category(rows)
+    for name in ["code", "documentation", "configuration", "other"]:
+        groups.setdefault(name, [])
     output_path = Path(__file__).with_name("diagnosis.md")
     _write_markdown(groups, output_path)
 

--- a/pln_primeros_pasos_codex_crossref_update_v_4_20250807.md
+++ b/pln_primeros_pasos_codex_crossref_update_v_4_20250807.md
@@ -1,6 +1,18 @@
-# PLN · Primeros pasos Codex — Update Crossref y Compliance V4 (2025-08-07)
-
 ---
+CODE: PLN_PRIMEROS_PASOS_CROSSREF
+ID: pln_primeros_pasos_codex
+VERSION: v4.0-2025-08-07
+ROUTE: pln_primeros_pasos_codex_crossref_update_v_4_20250807.md
+CROSSREF:
+  - lifecycle/temp/rw_b_blueprint_v_4_extendido_2025_08_06.md
+  - lifecycle/temp/rw_b_master_plan_v_4_extendido_2025_08_06.md
+  - lifecycle/temp/prompt_codex_baseline_v_4_check.md
+  - core/rulset/RULE_CODING_COMPLIANCE_V4.md
+AUTHOR: AingZ_Platform
+DATE: 2025-08-07
+---
+
+# PLN · Primeros pasos Codex — Update Crossref y Compliance V4 (2025-08-07)
 
 ## Objetivo
 Automatizar la actualización dinámica de crossref, metadatos y validación compliance en TODO el árbol del repo, tras cualquier movimiento de archivos clave o cambios en la estructura.
@@ -57,4 +69,15 @@ Automatizar la actualización dinámica de crossref, metadatos y validación com
 ---
 
 **Fin PLN primeros pasos Codex para compliance V4**
+
+## OutputTemplate
+```yaml
+CODE:
+ID:
+VERSION:
+ROUTE:
+CROSSREF:
+AUTHOR:
+DATE:
+```
 


### PR DESCRIPTION
## Summary
- cache V4 blueprint, master plan, prompt codex, and ruleset paths for dynamic crossrefs
- add YAML metadata and OutputTemplate to the crossref plan document
- ensure baseline diagnosis handles json configs and always emits category sections
- log repository sweep and metadata validation results

## Testing
- `python ops/scripts/litw_sweep.py`
- `python ops/update_crossrefs.py`
- `python ops/validate_metadata.py README.md pln_primeros_pasos_codex_crossref_update_v_4_20250807.md`
- `python ops/scripts/run_codex_baseline_v4_check.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895ef49d8b4832992175d3c12bff26a