### PR TITLE
docs: add purge log subbucket readme

### DIFF
--- a/ops/changelog.md
+++ b/ops/changelog.md
@@ -63,6 +63,8 @@ Example entry format:
 - 2025-08-08 | pln_primeros_pasos_codex_crossref_update_v_4_20250807.md | Removed temporary plan after crossref updates
 - 2025-08-08 | repo | Moved changelog and lessons_learned to ops bucket and updated references
 
+- 2025-08-10 | ops/log/purge/readme_ops_log_purge_v_4.md | Added purge log subbucket README
+
 ## OutputTemplate
 ```yaml
 CODE:

--- a/ops/lessons_learned.md
+++ b/ops/lessons_learned.md
@@ -58,6 +58,8 @@ Example entry format:
 - 2025-08-08 | pln_primeros_pasos_codex_crossref_update_v_4_20250807.md | Temporary plan removed after crossref validation
 - 2025-08-08 | repo | Centralizing changelog and lessons_learned under ops simplifies maintenance of dynamic crossrefs
 
+- 2025-08-10 | ops/log/purge/readme_ops_log_purge_v_4.md | Documented retention policy and workflow linkage
+
 ## OutputTemplate
 ```yaml
 CODE:

--- a/ops/log/purge/readme_ops_log_purge_v_4.md
+++ b/ops/log/purge/readme_ops_log_purge_v_4.md
@@ -1,0 +1,35 @@
+---
+CODE: OPS
+ID: readme_ops_log_purge_v_4
+VERSION: v4.0-2025-08-10
+ROUTE: /home/runner/work/AingZ_Platform/AingZ_Platform/ops/log/purge/readme_ops_log_purge_v_4.md
+CROSSREF:
+  - lifecycle/temp/rw_b_blueprint_v_4_extendido_2025_08_06.md
+  - lifecycle/temp/rw_b_master_plan_v_4_extendido_2025_08_06.md
+  - lifecycle/temp/prompt_codex_baseline_v_4_check.md
+  - core/rulset/RULE_CODING_COMPLIANCE_V4.md
+  - .github/workflows/aingz_purge_fixes_v2.yml
+AUTHOR: AingZ_Platform
+DATE: 2025-08-10
+---
+# Purge Logs Subbucket
+
+## Objetivo
+Repositorio específico para los registros de purga automática y manual dentro de `ops/log`. Sirve como bitácora de las tareas de limpieza ejecutadas sobre los buckets de logs.
+
+## Política de Retención
+Los registros se conservan por un máximo de 30 días. Pasado ese período se eliminan automáticamente mediante el workflow `aingz_purge_fixes_v2.yml`.
+
+## Workflows Relacionados
+- Workflow de purga: [`.github/workflows/aingz_purge_fixes_v2.yml`](../../../.github/workflows/aingz_purge_fixes_v2.yml)
+
+## OutputTemplate
+```yaml
+CODE:
+ID:
+VERSION:
+ROUTE:
+CROSSREF:
+AUTHOR:
+DATE:
+```


### PR DESCRIPTION
## Summary
- document purge log retention and workflow references in dedicated subbucket README
- record purge log documentation in changelog and lessons learned

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898f9e689548329b8bae5872563db57