### PR TITLE
fix: update prompt codex crossref

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ file: readme.md
 version: v4.0-20250807
 crossref_blueprint: lifecycle/temp/rw_b_blueprint_v_4_extendido_2025_08_06.md
 crossref_masterplan: lifecycle/temp/rw_b_master_plan_v_4_extendido_2025_08_06.md
-crossref_prompt_codex: null
-crossref_ruleset: core/rulset/RULE_NAMING_METADATA_CROSSREF_V1.md
+crossref_prompt_codex: lifecycle/temp/prompt_codex_baseline_v_4_check.md
+crossref_ruleset: core/rulset/RULE_CODING_COMPLIANCE_V4.md
 status: migracion-actualizacion-v4
 note: "Validar crossref dinámico y barrido 100% repo tras cada ciclo."
 ```

--- a/ops/changelog.md
+++ b/ops/changelog.md
@@ -86,3 +86,8 @@ DATE:
 - 2025-08-10 | README.md | TRG_CONSOLIDATE_TL failed: [Errno 2] No such file or directory: 'TRG_CONSOLIDATE_TL'
 - 2025-08-10 | README.md | TRG_LSWP failed: [Errno 2] No such file or directory: 'TRG_LSWP'
 - 2025-08-10 | README.md | Updated crossref: crossref_prompt_codex: lifecycle/temp/prompt_codex_baseline_v_4_check.md -> crossref_prompt_codex: null
+- 2025-08-10 | README.md | TRG_AUDIT_TL failed: [Errno 2] No such file or directory: 'TRG_AUDIT_TL'
+- 2025-08-10 | README.md | TRG_CONSOLIDATE_TL failed: [Errno 2] No such file or directory: 'TRG_CONSOLIDATE_TL'
+- 2025-08-10 | README.md | TRG_LSWP failed: [Errno 2] No such file or directory: 'TRG_LSWP'
+- 2025-08-10 | README.md | Updated crossref: crossref_prompt_codex: null -> crossref_prompt_codex: lifecycle/temp/prompt_codex_baseline_v_4_check.md
+- 2025-08-10 | README.md | Updated crossref: crossref_ruleset: core/rulset/RULE_NAMING_METADATA_CROSSREF_V1.md -> crossref_ruleset: core/rulset/RULE_CODING_COMPLIANCE_V4.md

--- a/ops/lessons_learned.md
+++ b/ops/lessons_learned.md
@@ -75,3 +75,8 @@ DATE:
 - 2025-08-10 | README.md | TRG_CONSOLIDATE_TL failed: [Errno 2] No such file or directory: 'TRG_CONSOLIDATE_TL'
 - 2025-08-10 | README.md | TRG_LSWP failed: [Errno 2] No such file or directory: 'TRG_LSWP'
 - 2025-08-10 | README.md | Updated crossref: crossref_prompt_codex: lifecycle/temp/prompt_codex_baseline_v_4_check.md -> crossref_prompt_codex: null
+- 2025-08-10 | README.md | TRG_AUDIT_TL failed: [Errno 2] No such file or directory: 'TRG_AUDIT_TL'
+- 2025-08-10 | README.md | TRG_CONSOLIDATE_TL failed: [Errno 2] No such file or directory: 'TRG_CONSOLIDATE_TL'
+- 2025-08-10 | README.md | TRG_LSWP failed: [Errno 2] No such file or directory: 'TRG_LSWP'
+- 2025-08-10 | README.md | Updated crossref: crossref_prompt_codex: null -> crossref_prompt_codex: lifecycle/temp/prompt_codex_baseline_v_4_check.md
+- 2025-08-10 | README.md | Updated crossref: crossref_ruleset: core/rulset/RULE_NAMING_METADATA_CROSSREF_V1.md -> crossref_ruleset: core/rulset/RULE_CODING_COMPLIANCE_V4.md

--- a/ops/paths_cache.json
+++ b/ops/paths_cache.json
@@ -1,8 +1,6 @@
 {
-  "Prompt_Codex_Baseline_V4_Check.md": null,
+  "prompt_codex_baseline_v_4_check.md": "lifecycle/temp/prompt_codex_baseline_v_4_check.md",
   "rw_b_blueprint_v_4_extendido_2025_08_06.md": "lifecycle/temp/rw_b_blueprint_v_4_extendido_2025_08_06.md",
   "rw_b_master_plan_v_4_extendido_2025_08_06.md": "lifecycle/temp/rw_b_master_plan_v_4_extendido_2025_08_06.md",
-  "blueprint_rw_b_platform_v_3_20250803.md": "lifecycle/temp/rw_b_blueprint_v_4_extendido_2025_08_06.md",
-  "mpln_master_plan_rw_b_v_3_20250803.md": "lifecycle/temp/rw_b_master_plan_v_4_extendido_2025_08_06.md",
   "core/rulset/RULE_CODING_COMPLIANCE_V4.md": "core/rulset/RULE_CODING_COMPLIANCE_V4.md"
 }

--- a/ops/sweep_paths.py
+++ b/ops/sweep_paths.py
@@ -3,7 +3,7 @@ import os
 from pathlib import Path
 
 TARGETS = [
-    "Prompt_Codex_Baseline_V4_Check.md",
+    "prompt_codex_baseline_v_4_check.md",
     "rw_b_blueprint_v_4_extendido_2025_08_06.md",
     "rw_b_master_plan_v_4_extendido_2025_08_06.md",
     "core/rulset/RULE_CODING_COMPLIANCE_V4.md",


### PR DESCRIPTION
## Summary
- align sweep script to new `prompt_codex_baseline_v_4_check.md` filename
- regenerate paths cache and propagate updated crossref to README
- log crossref update in changelog and lessons learned

## Testing
- `python ops/sweep_paths.py`
- `python ops/update_crossrefs.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68990694f45c8329b7811b531685fab9