### PR TITLE
fix diff guard numstat processing

### DIFF
--- a/.github/workflows/aingz_diff_guard.yml
+++ b/.github/workflows/aingz_diff_guard.yml
@@ -32,13 +32,13 @@ jobs:
 
           added=0
           removed=0
-          while read -r a r path; do
+          set +m
+          shopt -s lastpipe
+          printf '%s\n' "$ns" | while read -r a r path; do
             # los binarios aparecen como '-'
             [[ "$a" =~ ^[0-9]+$ ]] && added=$((added + a))
             [[ "$r" =~ ^[0-9]+$ ]] && removed=$((removed + r))
-          done <<'EOF'
-          '"$ns"'
-          EOF
+          done
 
           echo "added=$added removed=$removed"
           # margen de 10 líneas para evitar falsos positivos


### PR DESCRIPTION
## Summary
- fix numstat processing to pipe diff output into loop and compute added/removed counts

## Testing
- `pytest`
- custom script to verify diff added/removed counts

------
https://chatgpt.com/codex/tasks/task_e_68990e84986c8329abdc98c2fce2bfd3