### PR TITLE
fix: sanitize purge path before chaining

### DIFF
--- a/.github/workflows/aingz_orchestrator.yml
+++ b/.github/workflows/aingz_orchestrator.yml
@@ -102,14 +102,14 @@ jobs:
             const { owner, repo } = context.repo;
             const branch = context.ref.replace('refs/heads/','');
             const reason = process.env.ORCH_REASON || 'orchestrate-v4';
-            const purgePath = `${{ toJSON(needs.preflight.outputs.purge_path) }}`; // path resultante del preflight
+            const purgePath = ${{ toJSON(needs.preflight.outputs.purge_path) }}; // path resultante del preflight
 
             const chain = [
               '.github/workflows/aingz_tallado_readmes.yml',
               '.github/workflows/aingz_crossref_fix.yml',
               '.github/workflows/aingz_harvest_knowledge.yml',
               '.github/workflows/aingz_incoherence_report.yml',
-              purgePath
+              (purgePath || '').replace(/^"|"$/g, '')
             ];
 
             async function findWorkflowIdByPath(path) {


### PR DESCRIPTION
## Summary
- sanitize purge path before adding to workflow chain

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68990e90edc48329ab854359f35e2726