### PR TITLE
fix: usar cadena triple para OutputTemplate

### DIFF
--- a/.github/workflows/aingz_tallado_readmes.yml
+++ b/.github/workflows/aingz_tallado_readmes.yml
@@ -115,7 +115,11 @@ jobs:
 
             # Asegurar OutputTemplate
             if not has_output_tpl(body):
-              body = body.rstrip() + "\n\n## OutputTemplate\n```yaml\nCODE:\nID:\nVERSION:\nROUTE:\nCROSSREF:\nAUTHOR:\nDATE:\n```\n"
+              body = body.rstrip() + (
+                "\n\n## OutputTemplate\n```yaml\n"
+                "CODE:\nID:\nVERSION:\nROUTE:\nCROSSREF:\nAUTHOR:\nDATE:\n"
+                "```\n"
+              )
 
             new_txt = "\n".join(fm_lines) + body
             write(p, new_txt)


### PR DESCRIPTION
## Summary
- asegurar que el tallado de READMEs utilice una cadena triple correctamente escapada al añadir `OutputTemplate`

## Testing
- `pytest`
- `python - <<'PY' ...`

------
https://chatgpt.com/codex/tasks/task_e_68991044eea48329b3d5bb82fcc0aa8c