### PR TITLE
chore: relocate baseline docs to workbench

### DIFF
--- a/core/doc/workbench/dir_tree_v_1_4_baseline_locked.md
+++ b/core/doc/workbench/dir_tree_v_1_4_baseline_locked.md
@@ -1,6 +1,6 @@
 ---
 
-file: core/doc/workbench/AINGZ\_V5\_DirTree\_v1\_4\_baseline\_locked.md code: ARBBL name: DirTreeV14BaselineLocked version: v1.4.2 date: 2025-08-18 owner: AingZ\_Platform · RwB status: locked referencias: [DirTreeV14Aligned, aing\_z\_v\_5\_dir\_tree\_v\_1.md] triggers: [TRG\_BASELINE\_LOCK] cambios:
+file: core/doc/workbench/dir_tree_v_1_4_baseline_locked.md code: ARBBL name: DirTreeV14BaselineLocked version: v1.4.2 date: 2025-08-18 owner: AingZ\_Platform · RwB status: locked referencias: [DirTreeV14Aligned, aing\_z\_v\_5\_dir\_tree\_v\_1.md] triggers: [TRG\_BASELINE\_LOCK] cambios:
 
 - 2025-08-18: Freeze de la vista alineada con notas y códigos. checks:
 - Vista ASCII con columnas fijas
@@ -102,7 +102,7 @@ output_example:
   baseline_id: BL-2025-08-18-DirTree-v1.4.2
   created_at: 2025-08-18T00:00:00-03:00
   result:
-    - files_frozen: [core/doc/workbench/AINGZ_V5_DirTree_v1_4_baseline_locked.md]
+    - files_frozen: [core/doc/workbench/dir_tree_v_1_4_baseline_locked.md]
   log:
     - step1: qa_pass
     - step2: checkpoint

--- a/core/doc/workbench/glossary_baseline_v_1_locked.md
+++ b/core/doc/workbench/glossary_baseline_v_1_locked.md
@@ -1,6 +1,6 @@
 ---
 
-file: core/doc/workbench/AINGZ\_V5\_Glossary\_Baseline\_v1\_locked.md code: GBL name: GlossaryBaselineV1 version: v1.0.0 date: 2025-08-18 owner: AingZ\_Platform · RwB status: locked referencias:
+file: core/doc/workbench/glossary_baseline_v_1_locked.md code: GBL name: GlossaryBaselineV1 version: v1.0.0 date: 2025-08-18 owner: AingZ\_Platform · RwB status: locked referencias:
 
 - GREAL (GlossaryRealV1)
 - GTBL (Glossary\_Template\_Baseline\_v1.1\_Locked)
@@ -54,7 +54,7 @@ output_example:
   baseline_id: BL-2025-08-18-Glossary-v1.0.0
   created_at: 2025-08-18T00:00:00-03:00
   result:
-    - files_frozen: [core/doc/workbench/AINGZ_V5_Glossary_Baseline_v1_locked.md]
+    - files_frozen: [core/doc/workbench/glossary_baseline_v_1_locked.md]
   log:
     - step1: qa_pass
     - step2: checkpoint

--- a/core/doc/workbench/ruleset_baseline_v_1_locked.md
+++ b/core/doc/workbench/ruleset_baseline_v_1_locked.md
@@ -1,6 +1,6 @@
 ---
 
-file: core/doc/workbench/AINGZ\_V5\_Ruleset\_Baseline\_v1\_locked.md code: RBL name: RulesetBaselineV1 version: v1.0.0 date: 2025-08-18 owner: AingZ\_Platform · RwB status: locked referencias:
+file: core/doc/workbench/ruleset_baseline_v_1_locked.md code: RBL name: RulesetBaselineV1 version: v1.0.0 date: 2025-08-18 owner: AingZ\_Platform · RwB status: locked referencias:
 
 - RREAL (RulesetRealV1)
 - RSTBL (Ruleset\_Template\_Baseline\_v1.1\_Locked)
@@ -87,7 +87,7 @@ output_example:
   baseline_id: BL-2025-08-18-Ruleset-v1.0.0
   created_at: 2025-08-18T00:00:00-03:00
   result:
-    - files_frozen: [core/doc/workbench/AINGZ_V5_Ruleset_Baseline_v1_locked.md]
+    - files_frozen: [core/doc/workbench/ruleset_baseline_v_1_locked.md]
   log:
     - step1: qa_pass
     - step2: checkpoint

--- a/legacy/templates/dir_tree_v_1_4_baseline_locked.md
+++ b/legacy/templates/dir_tree_v_1_4_baseline_locked.md
@@ -1,6 +1,6 @@
 ---
 
-file: core/doc/workbench/AINGZ\_V5\_DirTree\_v1\_4\_baseline\_locked.md code: ARBBL name: DirTreeV14BaselineLocked version: v1.4.2 date: 2025-08-18 owner: AingZ\_Platform · RwB status: locked referencias: [DirTreeV14Aligned, aing\_z\_v\_5\_dir\_tree\_v\_1.md] triggers: [TRG\_BASELINE\_LOCK] cambios:
+file: core/doc/workbench/dir_tree_v_1_4_baseline_locked.md code: ARBBL name: DirTreeV14BaselineLocked version: v1.4.2 date: 2025-08-18 owner: AingZ\_Platform · RwB status: locked referencias: [DirTreeV14Aligned, aing\_z\_v\_5\_dir\_tree\_v\_1.md] triggers: [TRG\_BASELINE\_LOCK] cambios:
 
 - 2025-08-18: Freeze de la vista alineada con notas y códigos. checks:
 - Vista ASCII con columnas fijas
@@ -102,7 +102,7 @@ output_example:
   baseline_id: BL-2025-08-18-DirTree-v1.4.2
   created_at: 2025-08-18T00:00:00-03:00
   result:
-    - files_frozen: [core/doc/workbench/AINGZ_V5_DirTree_v1_4_baseline_locked.md]
+    - files_frozen: [core/doc/workbench/dir_tree_v_1_4_baseline_locked.md]
   log:
     - step1: qa_pass
     - step2: checkpoint


### PR DESCRIPTION
## Summary
- move baseline dir tree, glossary, and ruleset docs to core/doc/workbench
- update internal references to new locations

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b320faf248832986fab9b1b598008d