### PR TITLE
feat: add unified baselines documentation

### DIFF
--- a/core/doc/workbench/AINGZ_V5_Baselines_Unificados_v1_4_1_locked.md
+++ b/core/doc/workbench/AINGZ_V5_Baselines_Unificados_v1_4_1_locked.md
@@ -1,0 +1,50 @@
+---
+file: core/doc/workbench/AINGZ_V5_Baselines_Unificados_v1_4_1_locked.md
+code: A5BUBL
+name: AINGZ_V5_Baselines_Unificados
+version: v1.4.1
+date: 2025-08-19
+owner: AingZ_Platform · RwB
+status: locked
+referencias:
+  - DirTreeV14BaselineLocked
+  - GlossaryBaselineV1
+  - RulesetBaselineV1
+triggers: [TRG_BASELINE_LOCK]
+cambios:
+  - 2025-08-19: Unificación de baselines congelados.
+checks:
+  - Rutas apuntan a main/data_base
+---
+
+# Baselines Unificados — v1.4.1
+
+**Baseline-ID**: BL-2025-08-19-Baselines-v1.4.1  
+**DirTree**: `main/data_base/dir_tree_v_1_4_baseline_locked.md`  
+**Glosario**: `main/data_base/glossary_baseline_v_1_locked.md`  
+**Ruleset**: `main/data_base/ruleset_baseline_v_1_locked.md`
+
+> Artefacto congelado que referencia los baselines finales del repositorio. Cualquier modificación requiere nueva revisión y lock.
+
+## Referencias
+
+- [DirTree v1.4.2](../../../main/data_base/dir_tree_v_1_4_baseline_locked.md)
+- [Glosario v1.0.0](../../../main/data_base/glossary_baseline_v_1_locked.md)
+- [Ruleset v1.0.0](../../../main/data_base/ruleset_baseline_v_1_locked.md)
+
+## OutputTemplate
+
+```yaml
+output_example:
+  status: BASELINES_UNIFIED_LOCKED
+  baseline_id: BL-2025-08-19-Baselines-v1.4.1
+  created_at: 2025-08-19T00:00:00-03:00
+  result:
+    dir_tree: main/data_base/dir_tree_v_1_4_baseline_locked.md
+    glossary: main/data_base/glossary_baseline_v_1_locked.md
+    ruleset: main/data_base/ruleset_baseline_v_1_locked.md
+  log:
+    - step1: qa_pass
+    - step2: checkpoint
+    - step3: freeze
+```

--- a/core/doc/workbench/AINGZ_V5_Baselines_Unificados_v_1_4_ascii_tree.md
+++ b/core/doc/workbench/AINGZ_V5_Baselines_Unificados_v_1_4_ascii_tree.md
@@ -1,0 +1,25 @@
+---
+file: core/doc/workbench/AINGZ_V5_Baselines_Unificados_v_1_4_ascii_tree.md
+code: A5BUAT
+name: AINGZ_V5_Baselines_Unificados_AsciiTree
+version: v1.4
+date: 2025-08-19
+owner: AingZ_Platform · RwB
+status: locked
+referencias:
+  - AINGZ_V5_Baselines_Unificados_v1_4_1_locked.md
+triggers: [TRG_VIEW_ASCII]
+cambios:
+  - 2025-08-19: Vista ASCII de baselines unificados.
+checks:
+  - Representación apunta a main/data_base
+---
+
+# Árbol ASCII — Baselines Unificados v1.4
+
+```text
+main/data_base
+├── dir_tree_v_1_4_baseline_locked.md
+├── glossary_baseline_v_1_locked.md
+└── ruleset_baseline_v_1_locked.md
+```

--- a/main/data_base/dir_tree_v_1_4_baseline_locked.md
+++ b/main/data_base/dir_tree_v_1_4_baseline_locked.md
@@ -1,0 +1,111 @@
+---
+
+file: core/doc/workbench/dir_tree_v_1_4_baseline_locked.md code: ARBBL name: DirTreeV14BaselineLocked version: v1.4.2 date: 2025-08-18 owner: AingZ\_Platform · RwB status: locked referencias: [DirTreeV14Aligned, aing\_z\_v\_5\_dir\_tree\_v\_1.md] triggers: [TRG\_BASELINE\_LOCK] cambios:
+
+- 2025-08-18: Freeze de la vista alineada con notas y códigos. checks:
+- Vista ASCII con columnas fijas
+- Índice de códigos presente
+- Descripciones breves coherentes
+
+---
+
+# Baseline Lock — Árbol de Directorios v1.4.2
+
+**Baseline-ID**: BL-2025-08-18-DirTree-v1.4.2\
+**Origen**: DirTreeV14Aligned (v1.4.2)\
+**Alcance**: Estructura visual con [CODE] y descripción alineados.
+
+> Estado congelado. Cualquier cambio futuro debe realizarse en un *working copy* y proponer nuevo lock.
+
+## Árbol congelado
+
+```text
+AingZ_Platform                                        [ROOT]  — raíz del repositorio
+├── main                                              [MAIN]  — código y datos activos
+│   ├── data_base                                     [DB]    — base de conocimiento
+│   │   ├── core_actv                                 [CACT]  — activos nucleares
+│   │   │   ├── docs                                  [DOCS]  — media y documentación
+│   │   │   │   ├── audio                             [AUD]   — insumos de audio
+│   │   │   │   ├── image                             [IMG]   — insumos de imagen
+│   │   │   │   ├── video                             [VID]   — insumos de video
+│   │   │   │   ├── library                           [LIB]   — papers y libros
+│   │   │   │   └── onboard                           [ONB]   — materiales de onboarding
+│   │   │   ├── data                                  [DATA]  — datasets y metadatos
+│   │   │   │   ├── semantics                         [SEM]   — semántica de plataforma
+│   │   │   │   │   ├── glossary                      [GLOS]  — glosarios
+│   │   │   │   │   ├── dicts                         [DICT]  — diccionarios
+│   │   │   │   │   ├── code_dict                     [CDCT]  — mapeos de código
+│   │   │   │   │   ├── trigger_dict                  [TDCT]  — dicc. de triggers
+│   │   │   │   │   ├── app_dict                      [ADCT]  — apps y aliases
+│   │   │   │   │   ├── prompt_dict                   [PDCT]  — prompts estándar
+│   │   │   │   │   ├── ingest_prompts                [INGP]  — prompts de ingesta
+│   │   │   │   │   ├── vocabulary                    [VOC]   — vocabulario controlado
+│   │   │   │   │   └── ruleset                        [RSET]  — reglas y políticas
+│   │   │   │   ├── ai_learn                          [AILE]  — aprendizaje de la IA
+│   │   │   │   │   ├── learning                      [LEARN] — currícula
+│   │   │   │   │   ├── evaluation                    [EVAL]  — evals y métricas
+│   │   │   │   │   ├── insights                      [INSI]  — hallazgos
+│   │   │   │   │   ├── fine_tuning                   [FTUN]  — ajustes finos
+│   │   │   │   │   ├── few_shot                      [FSHT]  — ejemplos canónicos
+│   │   │   │   │   ├── relevance                     [RELV]  — ranking/recall
+│   │   │   │   │   ├── training                      [TRNG]  — sesiones de training
+│   │   │   │   │   └── feedback                      [FDBK]  — retroalimentación
+│   │   │   │   ├── develop                           [DEVP]  — desarrollo de plataforma
+│   │   │   │   │   ├── ruleset                       [RDEV]  — reglas de dev
+│   │   │   │   │   ├── config                        [CNFG]  — configuración
+│   │   │   │   │   ├── setup                         [SETUP] — instalación
+│   │   │   │   │   ├── customization                 [CSTM]  — personalización
+│   │   │   │   │   ├── specs                         [SPECS] — especificaciones
+│   │   │   │   │   ├── preferences                   [PREF]  — preferencias
+│   │   │   │   │   ├── connectors                    [CNTR]  — puertos/adaptadores
+│   │   │   │   │   └── orchestrator                  [ORCH]  — orquestador/wf
+│   │   │   │   ├── out_template                      [OTPL]  — plantillas de salida
+│   │   │   │   │   ├── mtx                           [MTX]   — matrices comparativas
+│   │   │   │   │   │   ├── matrix                    [MATR]  — scoring
+│   │   │   │   │   │   ├── table                     [TBLS]  — tablas
+│   │   │   │   │   │   ├── record_sheet              [RCSH]  — planillas
+│   │   │   │   │   │   ├── mapping                   [MAPP]  — mapeos
+│   │   │   │   │   │   ├── relation                  [RELN]  — relaciones
+│   │   │   │   │   │   ├── validation                [VALD]  — validaciones
+│   │   │   │   │   │   └── comparison                [COMP]  — comparativas
+│   │   │   │   │   ├── docs                          [OTPD]  — docs para outputs
+│   │   │   │   │   ├── workspaces                    [WSPC]  — espacios de trabajo
+│   │   │   │   │   ├── platform_arch                 [PARCH] — arq de plataforma
+│   │   │   │   │   └── ai_tools                      [ATOOL] — herramientas IA
+│   │   │   │   └── guides                            [GUID]  — guías operativas
+│   │   │   │       ├── planin                        [PLIN]  — planeamiento
+│   │   │   │       │   ├── mpln                      [MPLN]  — master plan
+│   │   │   │       │   └── brainstorm_crtv           [BCRT]  — ideación
+│   │   │   │       ├── run_control                   [RCTL]  — ejecución/QA
+│   │   │   │       └── pipeline                      [PIPE]  — flujos/ETL
+│   │   │   ├── wf_playbooks                          [WF]    — playbooks de workflows
+│   │   │   └── kns_ctx_vivo                          [KCTX]  — contexto vivo
+│   │   ├── core_dev                                  [CDEV]  — desarrollo núcleo
+│   │   └── core_arch_platform                         [CARC]  — arq. de plataforma
+├── log                                               [LOG]   — cambios y calidad
+│   ├── changelog                                     [CHG]   — registro de cambios
+│   ├── validation                                    [VALG]  — logs de validación
+│   └── qms                                           [QMS]   — calidad y normas
+├── .github                                           [GIT]   — CI/CD y workflows
+├── packages                                          [PKG]   — paquetes y módulos
+├── ruleset                                           [RULE]  — políticas del repo
+└── scripts                                           [SCRIP] — utilidades y tareas
+```
+
+---
+
+## OutputTemplate
+
+```yaml
+output_example:
+  status: BASELINE_LOCKED
+  baseline_id: BL-2025-08-18-DirTree-v1.4.2
+  created_at: 2025-08-18T00:00:00-03:00
+  result:
+    - files_frozen: [core/doc/workbench/dir_tree_v_1_4_baseline_locked.md]
+  log:
+    - step1: qa_pass
+    - step2: checkpoint
+    - step3: freeze
+```
+

--- a/main/data_base/glossary_baseline_v_1_locked.md
+++ b/main/data_base/glossary_baseline_v_1_locked.md
@@ -1,0 +1,63 @@
+---
+
+file: core/doc/workbench/glossary_baseline_v_1_locked.md code: GBL name: GlossaryBaselineV1 version: v1.0.0 date: 2025-08-18 owner: AingZ\_Platform · RwB status: locked referencias:
+
+- GREAL (GlossaryRealV1)
+- GTBL (Glossary\_Template\_Baseline\_v1.1\_Locked)
+- DTTBL (DirTree\_Template\_Baseline\_v1.1\_Locked)
+- PCTRL (PlatformControlPrinciplesV1) triggers: [TRG\_BASELINE\_LOCK, TRG\_GLOSSARY] cambios:
+- 2025-08-18: Baseline real del glosario bloqueado según template. checks:
+- IDs únicos prefijo GLOS::
+- Refs sólo a buckets DIR::
+- Sin rutas de archivos ni anclas
+
+---
+
+# Baseline Lock — Glosario v1.0.0
+
+**Baseline-ID**: BL-2025-08-18-Glossary-v1.0.0\
+**Árbol**: BL-2025-08-18-DirTree-v1.4.2\
+**Snapshot**: `AINGZ_V5_Glossary_Real_v1.md` validado 2025-08-18
+
+> Estado congelado. Ediciones futuras en *working copy* del glosario y nuevo lock.
+
+## Tabla (snapshot)
+
+| ID (GLOS::)    | Término             | Definición breve                                          | Refs (DIR::)                                 | Sinónimos           | Tags            |
+| -------------- | ------------------- | --------------------------------------------------------- | -------------------------------------------- | ------------------- | --------------- |
+| GLOS::MAIN     | Glosario principal  | Conjunto de términos canónicos del monorepo.              | [[DIR::SEM]], [[DIR::ROOT]]                  | vocabulario         | #glosario       |
+| GLOS::BUCKET   | Bucket              | Agrupador lógico de carpetas y assets para un dominio.    | [[DIR::ROOT]], [[DIR::DB]]                   | carpeta lógica      | #estructura     |
+| GLOS::ASSET    | Asset               | Artefacto tangible y versionable bajo control QMS.        | [[DIR::DOCS]], [[DIR::OTPL]], [[DIR::SCRIP]] | artefacto           | #artefacto      |
+| GLOS::ENTITY   | Entidad             | Contrato semántico aplicable a datos o procesos.          | [[DIR::SEM]]                                 | concepto            | #semantica      |
+| GLOS::RULESET  | Ruleset             | Conjunto de reglas con router por plataforma/app/api.     | [[DIR::RULE]]                                | políticas           | #gobierno       |
+| GLOS::PIPE     | Pipeline            | Orquestación declarativa disparada por triggers.          | [[DIR::PIPE]], [[DIR::WF]]                   | flujo               | #orquestacion   |
+| GLOS::WFTRIG   | Trigger de workflow | Evento que inicia una ejecución o cambio de estado.       | [[DIR::WF]]                                  | disparador          | #workflow       |
+| GLOS::BASELOCK | Baseline lock       | Estado congelado e inmutable de un artefacto.             | [[DIR::LOG]]                                 | freeze              | #qms            |
+| GLOS::VREVIEW  | Version review      | Evaluación de deltas, riesgos y recomendación de versión. | [[DIR::OTPD]]                                | revisión de versión | #qms            |
+| GLOS::QMS      | QMS                 | Sistema de gestión de calidad, validaciones y normas.     | [[DIR::QMS]]                                 | calidad             | #qms            |
+| GLOS::KCTX     | Contexto vivo       | Estado operativo actual para continuidad de procesos.     | [[DIR::KCTX]]                                | estado activo       | #operacion      |
+| GLOS::AILE     | AI Learn            | Área de aprendizaje, evaluación y feedback de IA.         | [[DIR::AILE]]                                | mlops               | #ia             |
+| GLOS::DEVP     | Develop             | Configuración, conectores y orquestación desacoplada.     | [[DIR::DEVP]]                                | devops              | #plataforma     |
+| GLOS::OTPL     | Out Templates       | Plantillas de salida estandarizadas para entregables.     | [[DIR::OTPL]]                                | templates           | #documentacion  |
+| GLOS::GUID     | Guides              | Guías operativas y SOPs de la plataforma.                 | [[DIR::GUID]]                                | manuales            | #procedimientos |
+
+## Reglas y Checklist
+
+- Namespaces aprobados.
+- Sin enlaces a archivos ni anclas.
+
+## OutputTemplate
+
+```yaml
+output_example:
+  status: GLOSSARY_BASELINE_LOCKED
+  baseline_id: BL-2025-08-18-Glossary-v1.0.0
+  created_at: 2025-08-18T00:00:00-03:00
+  result:
+    - files_frozen: [core/doc/workbench/glossary_baseline_v_1_locked.md]
+  log:
+    - step1: qa_pass
+    - step2: checkpoint
+    - step3: freeze
+```
+

--- a/main/data_base/ruleset_baseline_v_1_locked.md
+++ b/main/data_base/ruleset_baseline_v_1_locked.md
@@ -1,0 +1,96 @@
+---
+
+file: core/doc/workbench/ruleset_baseline_v_1_locked.md code: RBL name: RulesetBaselineV1 version: v1.0.0 date: 2025-08-18 owner: AingZ\_Platform · RwB status: locked referencias:
+
+- RREAL (RulesetRealV1)
+- RSTBL (Ruleset\_Template\_Baseline\_v1.1\_Locked)
+- DTTBL (DirTree\_Template\_Baseline\_v1.1\_Locked)
+- PIPLT (Pipelines\_Template\_v1)
+- PCTRL (PlatformControlPrinciplesV1) triggers: [TRG\_BASELINE\_LOCK, TRG\_RULESET\_ROUTER] cambios:
+- 2025-08-18: Baseline real del ruleset bloqueado según template. checks:
+- goto sólo `DIR::`
+- Sin rutas de archivo ni anclas
+- Namespaces válidos
+
+---
+
+# Baseline Lock — Ruleset v1.0.0
+
+**Baseline-ID**: BL-2025-08-18-Ruleset-v1.0.0\
+**Árbol**: BL-2025-08-18-DirTree-v1.4.2\
+**Snapshot**: `AINGZ_V5_Ruleset_Real_v1.md` validado 2025-08-18
+
+> Estado congelado. Ediciones futuras en *working copy* de Ruleset y nuevo lock.
+
+## Router (snapshot)
+
+```yaml
+ruleset_router:
+  targets:
+    global:   [[DIR::RULE]]
+    platform: [[DIR::RULE]]
+    app:      [[DIR::RULE]]
+    api:      [[DIR::RULE]]
+  routes:
+    - match: { kind: platform, name: aws }
+      goto: [[DIR::RULE]]
+      section: platform/aws
+    - match: { kind: platform, name: gcp }
+      goto: [[DIR::RULE]]
+      section: platform/gcp
+    - match: { kind: platform, name: azure }
+      goto: [[DIR::RULE]]
+      section: platform/azure
+    - match: { kind: platform, name: local }
+      goto: [[DIR::RULE]]
+      section: platform/local
+    - match: { kind: app, name: console }
+      goto: [[DIR::RULE]]
+      section: app/console
+    - match: { kind: app, name: etl }
+      goto: [[DIR::RULE]]
+      section: app/etl
+    - match: { kind: app, name: ui }
+      goto: [[DIR::RULE]]
+      section: app/ui
+    - match: { kind: api, name: rest }
+      goto: [[DIR::RULE]]
+      section: api/rest
+    - match: { kind: api, name: graphql }
+      goto: [[DIR::RULE]]
+      section: api/graphql
+    - match: { kind: api, name: sdk }
+      goto: [[DIR::RULE]]
+      section: api/sdk
+```
+
+## Normas globales (snapshot)
+
+- Anti‑archivo activa.
+- Namespaces aprobados.
+- Roles R/A desde QMS.
+- ADR para cambios con impacto.
+
+## Integración PIPE
+
+- Rutas válidas habilitan ejecución en [[DIR::PIPE]].
+
+## Checklist
+
+-
+
+## OutputTemplate
+
+```yaml
+output_example:
+  status: RULESET_BASELINE_LOCKED
+  baseline_id: BL-2025-08-18-Ruleset-v1.0.0
+  created_at: 2025-08-18T00:00:00-03:00
+  result:
+    - files_frozen: [core/doc/workbench/ruleset_baseline_v_1_locked.md]
+  log:
+    - step1: qa_pass
+    - step2: checkpoint
+    - step3: freeze
+```
+


### PR DESCRIPTION
## Summary
- add locked document consolidating DirTree, Glossary, and Ruleset baselines
- include ascii tree view pointing to final baselines in `main/data_base`
- copy baseline artifacts into `main/data_base`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b32b2a1a288329b5e117d41605a5f0