### PR TITLE
Add directory planning and execution scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/scripts/apply_plan.sh
+++ b/scripts/apply_plan.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Apply or preview directory creation/removal plans.
+
+set -euo pipefail
+
+MODE="dry-run"
+if [[ ${1:-} == "--apply" ]]; then
+  MODE="apply"
+  shift
+elif [[ ${1:-} == "--dry-run" ]]; then
+  shift
+fi
+
+PLAN=${1:-}
+if [[ -z "$PLAN" ]]; then
+  echo "Usage: $0 [--dry-run|--apply] PLAN.yaml" >&2
+  exit 1
+fi
+
+read_plan() {
+  local section="$1"
+  awk -v section="$section" '
+    $0 ~ "^"section":" {flag=1; next}
+    /^[a-z]/ {flag=0}
+    flag && /^  -/ {print $2}
+  ' "$PLAN"
+}
+
+create_dirs=$(read_plan create)
+remove_dirs=$(read_plan remove)
+
+for d in $create_dirs; do
+  if [[ $MODE == "apply" ]]; then
+    mkdir -p "$d"
+    echo "Created $d"
+  else
+    echo "[DRY-RUN] Would create $d"
+  fi
+done
+
+for d in $remove_dirs; do
+  if [[ $MODE == "apply" ]]; then
+    rm -rf "$d"
+    echo "Removed $d"
+  else
+    echo "[DRY-RUN] Would remove $d"
+  fi
+done

--- a/scripts/gen_desired_state.py
+++ b/scripts/gen_desired_state.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Parse an ASCII tree representation and emit desired directory list.
+
+The script expects a text file containing an ASCII tree, similar to the
+output of the ``tree`` command.  Each line is inspected and directories are
+extracted heuristically by stripping the tree drawing characters and using
+indentation to build the path hierarchy.
+
+Usage::
+
+    python scripts/gen_desired_state.py ascii_view.txt desired_dirs.txt
+
+The resulting ``desired_dirs.txt`` will contain one directory path per line.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+from typing import Iterable, List
+
+TREE_CHARS = "│└├─"  # characters used by ``tree`` style drawings
+
+
+def parse_ascii_tree(lines: Iterable[str]) -> List[str]:
+    """Return a list of directory paths parsed from an ASCII tree."""
+    dirs: List[str] = []
+    stack: List[str] = []
+    for raw in lines:
+        if not raw.strip():
+            continue
+        # Remove tree drawing characters
+        cleaned = re.sub(f"^[{TREE_CHARS} ]+", "", raw.rstrip())
+        if not cleaned:
+            continue
+        indent = len(raw) - len(raw.lstrip())
+        level = indent // 4  # assume four spaces per level
+        stack = stack[:level]
+        name = cleaned.strip()
+        # Heuristic: ignore entries that look like files
+        if "." in name:
+            continue
+        path = "/".join(stack + [name])
+        dirs.append(path)
+        stack.append(name)
+    return dirs
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Parse ASCII tree into directory list")
+    parser.add_argument("ascii_view", help="File containing ASCII tree")
+    parser.add_argument("output", help="Output file for desired directories")
+    args = parser.parse_args()
+
+    with open(args.ascii_view, "r", encoding="utf8") as f:
+        dirs = parse_ascii_tree(f)
+
+    with open(args.output, "w", encoding="utf8") as f:
+        f.write("\n".join(dirs) + "\n")
+    print(f"Wrote {len(dirs)} directories to {args.output}")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/scripts/plan_sweep.py
+++ b/scripts/plan_sweep.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Generate a plan to remove directories not present in ``desired_dirs.txt``.
+
+The script walks the filesystem from a base path (current directory by
+default) and compares the discovered directories with the desired list.
+Directories absent from the desired list are written under the ``remove`` key
+of a simple YAML file.
+"""
+import argparse
+import os
+from pathlib import Path
+from typing import List
+
+
+def existing_dirs(base: Path) -> List[str]:
+    result: List[str] = []
+    for root, dirs, _ in os.walk(base):
+        # Ignore hidden directories such as .git
+        dirs[:] = [d for d in dirs if not d.startswith('.')]
+        rel_root = Path(root).relative_to(base)
+        for d in dirs:
+            path = (rel_root / d).as_posix().lstrip('./')
+            result.append(path)
+    return result
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate SWEEP_PLAN.yaml")
+    parser.add_argument("desired_dirs", help="Path to desired_dirs.txt")
+    parser.add_argument(
+        "output", nargs="?", default="SWEEP_PLAN.yaml", help="Output YAML file"
+    )
+    parser.add_argument(
+        "base", nargs="?", default=".", help="Base path to inspect for existing directories"
+    )
+    args = parser.parse_args()
+
+    with open(args.desired_dirs, "r", encoding="utf8") as f:
+        desired = {line.strip() for line in f if line.strip()}
+
+    base = Path(args.base)
+    current = set(existing_dirs(base))
+    to_remove = sorted(current - desired)
+
+    with open(args.output, "w", encoding="utf8") as f:
+        f.write("remove:\n")
+        for d in to_remove:
+            f.write(f"  - {d}\n")
+    print(f"Wrote {len(to_remove)} remove actions to {args.output}")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/scripts/plan_tree.py
+++ b/scripts/plan_tree.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Generate a plan to create directories from ``desired_dirs.txt``.
+
+The output is a simple YAML file with a single top-level key ``create``
+containing the list of directories.  The format is intentionally minimal to
+avoid requiring third-party dependencies.
+"""
+import argparse
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate TREE_PLAN.yaml")
+    parser.add_argument("desired_dirs", help="Path to desired_dirs.txt")
+    parser.add_argument(
+        "output", nargs="?", default="TREE_PLAN.yaml", help="Output YAML file"
+    )
+    args = parser.parse_args()
+
+    with open(args.desired_dirs, "r", encoding="utf8") as f:
+        dirs = [line.strip() for line in f if line.strip()]
+
+    with open(args.output, "w", encoding="utf8") as f:
+        f.write("create:\n")
+        for d in dirs:
+            f.write(f"  - {d}\n")
+    print(f"Wrote {len(dirs)} create actions to {args.output}")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()


### PR DESCRIPTION
## Summary
- parse ASCII tree into `desired_dirs.txt`
- generate `TREE_PLAN.yaml` and `SWEEP_PLAN.yaml` plans
- apply directory plans with optional dry-run

## Testing
- `python -m py_compile scripts/*.py`
- `bash scripts/apply_plan.sh --dry-run plan.yaml`

------
https://chatgpt.com/codex/tasks/task_e_68b32de6ca5083298aba878238f49245