### PR TITLE
Add context pack index in ruleset

### DIFF
--- a/ruleset/context_pack_index.md
+++ b/ruleset/context_pack_index.md
@@ -1,0 +1,29 @@
+---
+file: ruleset/context_pack_index.md
+code: KCTXIDX
+name: ContextPackIndex
+version: v1.0.0
+date: 2025-08-30
+owner: "AingZ_Platform · RwB"
+status: draft
+refs: [DIR::KCTX, RULESET::]
+triggers: [TRG_CONTEXT_PACKAGE]
+---
+
+# Índice de paquetes de contexto
+
+## chat_gpt_plus_knowledge_context_pack_v_1.md
+- Finalidad: guía de funcionalidades y límites de ChatGPT Plus para investigación, agentes y herramientas.
+- Relación con reglas: complementa el ruleset de la plataforma para uso de ChatGPT.
+
+## codex_knowledge_context_pack_literal.md
+- Finalidad: compilación literal del repositorio de Codex para referencia de desarrollo.
+- Relación con reglas: alinea la ejecución de Codex con las políticas y normas del ruleset.
+
+## V5/context_package_new_thread_v_1.md
+- Finalidad: empaquetar el estado base para reanudar trabajo en hilos nuevos.
+- Relación con reglas: vincula baselines (ARBBL, RBL, etc.) y mantiene la cadena README→RULESET→PIPE.
+
+## Política de actualización
+- Este índice se actualiza cuando se agregan o modifican paquetes de contexto.
+- triggers: [TRG_CONTEXT_PACKAGE]


### PR DESCRIPTION
## Summary
- add context pack index for ChatGPT Plus, Codex, and new thread packages
- document each pack's purpose and relation to rules
- establish update policy via TRG_CONTEXT_PACKAGE trigger

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b35e1739f08329b538f65dcb1f8111