### PR TITLE
docs: reference existing master ruleset

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,14 @@ Repositorio base para la implementación de la arquitectura V5. Mantiene los bas
 - `main/` – contiene la base de datos operativa (glosario, ruleset, dir tree) y artefactos core.
 - `V5/` – plantillas y minipacks oficiales para generar artefactos.
 - `legacy/` – material heredado pendiente de migración o archivado.
+- `ruleset/` – bucket central con el ruleset maestro y sus referencias.
 
 ## Reglas generales
 1. Los baselines bloqueados residen en `core/doc/workbench` y son la fuente de verdad.
 2. Toda nueva documentación debe incluir front‑matter válido y un OutputTemplate explícito.
 3. `wf_playbooks` reemplaza a `wf_template` en la estructura V5.
+
+Para obtener lineamientos unificados de todas las plataformas (ChatGPT, Codex, VSCode, GitHub, Obsidian, Excalidraw), consultar el [Ruleset maestro](ruleset/ruleset_master_v_1.md).
 
 ## Output Template
 ```markdown

--- a/ruleset/develop/ruleset_chatgpt_v_1.md
+++ b/ruleset/develop/ruleset_chatgpt_v_1.md
@@ -2,10 +2,11 @@
 file: ruleset/develop/ruleset_chatgpt_v_1.md code: RSCGP name: RulesetChatGPT version: v1.0.0 date: 2025-08-24 owner: "AingZ_Platform · RwB" status: draft
 ---
 
-# Ruleset ChatGPT Platform
+# Ruleset ChatGPT Platform (incluye ChatGPT-5 y AgentMode)
 
 ## Guidelines
 - Aplica el Glosario y Ruleset V5.
+- Compatible con todos los modelos ChatGPT, incluidos ChatGPT-5 y AgentMode.
 - Cada interacción debe registrar ruta exacta y OutputTemplate.
 - Respeta la literalidad (LSWP) y contratos ≤120 caracteres.
 


### PR DESCRIPTION
## Summary
- link repository documentation to the pre-existing master ruleset without introducing duplicate files
- clarify ChatGPT ruleset applies to all models including ChatGPT-5 and AgentMode

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b34df908dc83298a292e950fdf9a59