### PR TITLE
Add Obsidian master template proposals and asset analysis

### DIFF
--- a/templates/master_template_proposals/README.md
+++ b/templates/master_template_proposals/README.md
@@ -1,0 +1,38 @@
+---
+asset:
+  id: obsidian_master_templates_index_2025_09
+  name: ObsidianMasterTemplatesIndex
+  version: 0.1.0
+  owner: AingZ_Platform
+  status: draft
+context:
+  dom: KnowledgeArchitecture
+  goals:
+    - index_template_proposals
+    - document_selection_criteria
+  risks:
+    - misalignment_with_ruleset
+    - usability_overload
+compat:
+  platforms: [Obsidian]
+  connectors: [GitHub]
+  notes: "Master templates en exploración."
+---
+
+# Índice de propuestas para el nuevo master template Obsidian
+
+| Código | Nombre | Enfoque principal | Highlight interactivo |
+| ------ | ------ | ----------------- | ---------------------- |
+| `NEXUS` | [obsidian_master_template_proposal_nexus](obsidian_master_template_proposal_nexus.md) | Orquestación integral (estrategia + ejecución) | Tabs CSS + callouts DO/DON'T + Dashboard Dataview |
+| `ORBIT` | [obsidian_master_template_proposal_orbit](obsidian_master_template_proposal_orbit.md) | Ciclo de proyectos sostenibles | Timeline Buttons + Tracker KPIs |
+| `SPECTRUM` | [obsidian_master_template_proposal_spectrum](obsidian_master_template_proposal_spectrum.md) | Gestión de conocimiento y evidencias | Canvas embed + bibliografía dinámica |
+
+## Criterios de evaluación sugeridos
+
+1. **Alineación con RULESET_MAX**: campos obligatorios (`asset`, `context`, `compat`) y contratos visibles.
+2. **Eficiencia operativa**: número de acciones críticas accesibles sin abandonar la nota (Buttons, QuickAdd, Dataview inline).
+3. **Sostenibilidad y trazabilidad**: properties para impacto ambiental y `WK.log` para retroalimentación.
+4. **Escalabilidad**: capacidad de duplicar/parametrizar vía Templater y Dataview.
+5. **Experiencia de usuario**: claridad visual, modulación por modos (ejecutivo, foco, bitácora).
+
+> Seleccionar 1 propuesta como base maestra e iterar en modo `working`. Las otras pueden preservarse como variantes o componentes modulares.

--- a/templates/master_template_proposals/assets_landscape_analysis.md
+++ b/templates/master_template_proposals/assets_landscape_analysis.md
@@ -1,0 +1,72 @@
+---
+asset:
+  id: repo_asset_landscape_obsidian_2025_09
+  name: ObsidianAssetLandscape
+  version: 0.1.0
+  owner: AingZ_Platform
+  status: draft
+context:
+  dom: KnowledgeArchitecture
+  goals:
+    - map_existing_markdown_assets
+    - derive_requirements_for_master_template
+  risks:
+    - outdated_contracts
+    - inconsistent_front_matter
+compat:
+  platforms: [Obsidian, GPT5, CODEX]
+  connectors: [GitHub]
+  notes: "Baseline generated from local repository scan."
+---
+
+# Panorama de assets Markdown vigentes
+
+> Objetivo: obtener una visión holística de los artefactos activos para fundamentar un nuevo master template compatible con Obsidian y los lineamientos V5.
+
+## 1. Baselines bloqueados
+
+| Ruta | Propósito | Observaciones clave |
+| ---- | --------- | ------------------- |
+| `core/doc/workbench/AINGZ_V5_Baselines_Unificados_v1_4_1_locked.md` | Consolidado normativo V5 | Define taxonomía y nomenclaturas, sirve como contrato fuente para semántica y jerarquías operativas. |
+| `core/doc/workbench/ruleset_baseline_v_1_locked.md` | RULESET base | Enfatiza contratos claros, unicidad de IDs y estructuras modulares RULE/SPEC/ENV/PRC. |
+| `core/doc/workbench/glossary_baseline_v_1_locked.md` | Glosario | Garantiza semántica única con definiciones inmutables, imprescindible para properties en Obsidian. |
+
+## 2. Rulesets y contratos activos
+
+- `ruleset/ruleset_master_v_1.md` establece las políticas unificadas para plataformas GPT, Codex, GitHub y Obsidian, incluyendo requisitos de front‑matter y OutputTemplate obligatorio.
+- `aing_z_ruleset_max_universal_v_1_0_template.md` codifica el contrato universal con cabecera YAML y jerarquía RULE/SPEC/ENV/PRC, reforzando evidencias, trazabilidad y seguridad.
+
+## 3. Knowledge packs y contextos operativos
+
+| Asset | Rol | Oportunidades para el master template |
+| ----- | --- | ------------------------------------- |
+| `chat_gpt_plus_knowledge_context_pack_v_1.md` | Paquete de contexto rápido | Estructura ligera con secciones de contexto y prompts; útil para callouts de misión y DO/DON'T. |
+| `codex_knowledge_context_pack_literal.md` | Contexto literal | Contiene enumeraciones y snippets reutilizables, ideal para secciones plegables (`> [!example]`) en la plantilla. |
+| `kb_obsidian_plugins_core_community_unificado_v_2025_09_02.md` | Inventario Obsidian | Lista plugins core/community activos, habilita uso de Dataview, Buttons, Tracker, Templater y Canvas como elementos soportados. |
+
+## 4. Recursos operativos complementarios
+
+- `test_suite_obsidian_plugins_core_community_v_1.md` documenta verificaciones sugeridas para plugins, relevante para checklists automatizadas.
+- `ruleset/context_pack_index.md` inventaría context packs y minipacks, mostrando conveniencia de tablas índice y enlaces cruzados.
+- `main/data_base` replica baselines en modo distribuido (`glossary`, `dir_tree`, `core_actv`), indicando necesidad de queries Dataview o `dataviewjs` para sincronización ligera dentro del vault.
+
+## 5. Requisitos derivados para el nuevo master template
+
+1. **Front‑matter estricto**: campos `asset`, `context`, `compat` alineados con RULESET_MAX.
+2. **Interactividad Obsidian**: compatibilidad con callouts, Tabs (cssclass), Dataview, Buttons y Canvas embeds.
+3. **Contratos visibles**: secciones para Inputs/Outputs, checkpoints y logging (`WK.log`).
+4. **Modos de vista**: bloques plegables para modo Focus, Resumen ejecutivo y Detalle técnico.
+5. **Instrumentación KPI**: tablas dinámicas y trackers para métricas de sostenibilidad e impacto.
+
+## 6. KPI propuestos para evaluar adopción
+
+| KPI | Descripción | Métrica asociada |
+| --- | ----------- | ---------------- |
+| `TemplateCoverage` | % de notas nuevas que usan el master template | `#NotasTemplate / #NotasNuevas` (Dataview). |
+| `InteractionDepth` | Promedio de componentes interactivos utilizados por nota | Conteo de callouts, tasks y embeds. |
+| `SustainabilityTrace` | Notas con properties de impacto ambiental completadas | `dv.pages().where(p => p.impact_carbon)` |
+| `FeedbackLoopTime` | Tiempo desde creación a primera retroalimentación registrada | `date(first_feedback) - date(created)`. |
+
+---
+
+> Próximo paso: iterar sobre propuestas de plantilla y validar con repositorios espejo/plantillas existentes antes de publicación como `final`.

--- a/templates/master_template_proposals/obsidian_master_template_proposal_nexus.md
+++ b/templates/master_template_proposals/obsidian_master_template_proposal_nexus.md
@@ -1,0 +1,184 @@
+---
+asset:
+  id: obsidian_master_template_nexus_2025_09
+  name: ObsidianMasterTemplateNexus
+  version: 0.1.1
+  owner: AingZ_Platform
+  status: draft
+context:
+  dom: IntegratedOps
+  goals:
+    - unify_strategy_execution_logging
+    - maximize_obsidian_interactivity
+  risks:
+    - plugin_incompatibility
+    - overload_information_density
+compat:
+  platforms: [Obsidian, GPT5, CODEX]
+  connectors: [GitHub, GoogleDrive]
+  notes: "Pensado para vaults sincronizados con agentes IA."
+obsidian:
+  cssclass: tabs
+  required_plugins: [Dataview, Buttons, Tracker, Calendar, Excalidraw, Templater]
+  recommended_themes: [Minimal, ITS]
+---
+
+# <% tp.file.title %>
+
+> [!info] Resumen ejecutivo
+> - **Propósito**: <descripción breve>
+> - **North Star KPI**: `<kpi_principal>`
+> - **Estado actual**: `[[StatusBoard]]` | <% tp.date.now("YYYY-MM-DD") %>
+> - **Owner**: `@persona`
+
+---
+
+%% --- TAB 1: Estrategia --- %%
+
+## Estrategia · <% tp.date.now("YYYY") %> T<% tp.date.now("Q") %>
+
+> [!abstract] Objetivos clave
+> - O1 — <outcome>
+> - O2 — <outcome>
+> - O3 — <outcome>
+
+### Hipótesis y principios
+- **Hipótesis central** :: <texto>
+- **Principio de sostenibilidad** :: <texto>
+- **Riesgos críticos** :: <riesgo 1>, <riesgo 2>
+
+```dataview
+TABLE status as "Estado", impact_carbon as "Impacto CO₂", next_review as "Próxima revisión"
+FROM ""
+WHERE contains(tags, "initiative") and file.folder = this.file.folder
+SORT next_review asc
+```
+
+> [!tldr] Decisiones tomadas
+> 1. <Decisión clave>
+> 2. <Decisión clave>
+> 3. <Decisión clave>
+
+---
+
+%% --- TAB 2: Plan + Backlog --- %%
+
+## Plan operativo
+
+> [!todo] Backlog priorizado
+> - [ ] `#task/high` <acción 1>
+> - [ ] `#task/med` <acción 2>
+> - [ ] `#task/low` <acción 3>
+
+```dataviewjs
+const tasks = dv.pages().file.tasks
+  .where(t => !t.completed && t.path.includes(dv.current().file.folder));
+const grouped = dv.groupBy(tasks, t => t.tags.find(tag => tag.startsWith("#task/")) ?? "#task/none");
+dv.table(["Etiqueta", "Pendientes"], grouped.map(g => [g.key, g.rows.length]));
+```
+
+### Roadmap visual
+
+```mermaid
+gantt
+  title Roadmap sostenible
+  dateFormat  YYYY-MM-DD
+  section Fase 1
+  Kickoff                 :done,    des1, <% tp.date.now("YYYY") %>-09-01, 4d
+  Impact Assessment       :active,  des2, <% tp.date.now("YYYY") %>-09-05, 7d
+  section Fase 2
+  Deploy MVP              :         des3, <% tp.date.now("YYYY") %>-09-15, 10d
+  Feedback Loop           :         des4, after des3, 7d
+```
+
+> [!tip]- Plantillas rápidas (Buttons)
+> ^buttons-nexus
+> ```button
+> name Nueva bitácora diaria
+> type command
+> action Templater: Create new note from template
+> templater_template Daily/DailyLog
+> ```
+>
+> ```button
+> name Registrar feedback
+> type append
+> action ## Feedback\n- {{DATE:YYYY-MM-DD}} — <actor>: <resumen>
+> ```
+
+---
+
+%% --- TAB 3: Métricas + Impacto --- %%
+
+## Panel de métricas
+
+```dataview
+TABLE WITHOUT ID date as "Fecha", metric, value, unit, trend
+FROM ""
+WHERE type = "metric" and project = this.file.name
+SORT date desc
+LIMIT 10
+```
+
+> [!quote] Manifiesto de impacto
+> "Cada decisión debe reducir la huella ambiental sin comprometer la autonomía tecnológica."
+
+### Tracker de sostenibilidad
+
+```tracker
+searchType: frontmatter
+searchTarget: impact_carbon
+datasetName: Impacto CO2
+line:
+    title: "Kg CO₂ eq"
+    showPoints: true
+    cumulative: false
+```
+
+### Bitácora WK.log
+
+> [!note]- Registro continuo
+> ```yaml
+> wk_entry:
+>   when: <% tp.date.now("YYYY-MM-DDTHH:mm") %>
+>   actor: ai|human
+>   scope: <área>
+>   findings:
+>     - <insight>
+>   gaps:
+>     - <pendiente>
+>   next:
+>     - <acción>
+> ```
+
+---
+
+%% --- TAB 4: Referencias --- %%
+
+## Repositorios & Artefactos
+- [[ruleset/ruleset_master_v_1|Ruleset maestro]]
+- [[core/doc/workbench/AINGZ_V5_Baselines_Unificados_v1_4_1_locked|Baseline V5]]
+- [[kb_obsidian_plugins_core_community_unificado_v_2025_09_02|Plugins Obsidian]]
+
+> [!example]- Canvas & Excalidraw
+> - Canvas principal: `![[<% tp.file.title %>.canvas]]`
+> - Excalidraw: `![[<% tp.file.title %>_diagram.excalidraw]]`
+
+> [!faq]- Preguntas rápidas
+> 1. **¿Cuál es el próximo hito?** → Revisa `next_review` en Dataview.
+> 2. **¿Qué decisiones requieren confirmación?** → Callout *Decisiones tomadas*.
+> 3. **¿Cómo registrar feedback?** → Botón *Registrar feedback* o sección `WK.log`.
+
+---
+
+%% --- Footer --- %%
+
+```yaml
+OutputTemplate:
+  deliverable: MasterNote
+  formats: [markdown, json]
+  validation:
+    - check: Linter
+    - check: Dataview refresh
+  next_review: <% tp.date.now("YYYY-MM-DD", 7) %>
+```

--- a/templates/master_template_proposals/obsidian_master_template_proposal_orbit.md
+++ b/templates/master_template_proposals/obsidian_master_template_proposal_orbit.md
@@ -1,0 +1,209 @@
+---
+asset:
+  id: obsidian_master_template_orbit_2025_09
+  name: ObsidianMasterTemplateOrbit
+  version: 0.1.0
+  owner: AingZ_Platform
+  status: draft
+context:
+  dom: SustainableProjects
+  goals:
+    - orchestrate_end_to_end_project_cycles
+    - embed_environmental_kpis
+  risks:
+    - missed_stage_gates
+    - insufficient_feedback_logging
+compat:
+  platforms: [Obsidian, GPT5]
+  connectors: [GitHub, Notion]
+  notes: "Optimizado para proyectos iterativos con entregas quincenales."
+obsidian:
+  cssclass: cards tabs
+  required_plugins: [Dataview, Buttons, Tracker, Calendar, QuickAdd, Tasks]
+  automation:
+    quickadd_commands: ["Nueva bitácora", "Registrar hito"]
+---
+
+# {{VALUE:project_name?Proyecto sin nombre}}
+
+> [!success] Círculo ORBIT
+> **Discover → Design → Deploy → Sustain**
+>
+> - Hito activo: `<stage_active>`
+> - Fecha de cierre prevista: `<due_date>`
+> - Scorecard de madurez: `<maturity_score>/100`
+
+---
+
+## 0. Properties obligatorias
+
+```yaml
+project_id: <uid>
+owner: <responsable>
+co_owner: [<nombre>]
+stakeholders: [<stakeholder1>, <stakeholder2>]
+impact_carbon_target: <kg_co2_eq>
+impact_social_target: <indicador>
+review_cadence: P14D
+```
+
+---
+
+## 1. Discover
+
+> [!question]- Preguntas guía
+> - ¿Qué problema resolvemos?
+> - ¿Qué evidencia valida el dolor?
+> - ¿Cómo medimos el impacto ambiental y social?
+
+```dataview
+TABLE WITHOUT ID evidence_type as "Tipo", source as "Fuente", confidence as "Confianza"
+FROM ""
+WHERE stage = "discover" and project = this.file.name
+SORT confidence desc
+```
+
+> [!todo] Acciones Discover
+> - [ ] Mapear stakeholders críticos `#task/high`
+> - [ ] Completar análisis de ciclo de vida `#task/high`
+> - [ ] Documentar riesgos regulatorios `#task/med`
+
+```button
+name Pasar a Design
+type append
+action ## Hito Design\n- {{DATE:YYYY-MM-DD}} — Checklist de entrada completada ✅
+```
+
+---
+
+## 2. Design
+
+> [!example]- Blueprint sostenible
+> ```mermaid
+> flowchart LR
+>   A[Need] --> B(Concept)
+>   B --> C{Evaluación ambiental}
+>   C -->|OK| D[Prototype]
+>   C -->|Rework| B
+>   D --> E((MVP listo))
+> ```
+
+```dataviewjs
+const prototypes = dv.pages().where(p => p.stage == "design" && p.type == "prototype" && p.project == dv.current().file.name);
+const items = prototypes.array().map(p => ({
+  title: p.file.link,
+  readiness: p.readiness ?? 0,
+  energy: p.energy_intensity ?? "n/d"
+}));
+dv.list(items.map(it => `${it.title} — readiness: ${it.readiness}% · energía: ${it.energy}`));
+```
+
+> [!warning]- Gate de salida (Checklist)
+> - [ ] Validación con usuarios clave (≥3 entrevistas)
+> - [ ] Cálculo de impacto carbono < límite objetivo
+> - [ ] MVP aprobado por comité
+
+```button
+name Registrar decisión del comité
+type append
+action ### Comité Design\n- {{DATE:YYYY-MM-DD}} — Resultado: <Aprobado/Iterar>\n- Observaciones: <texto>
+```
+
+---
+
+## 3. Deploy
+
+> [!tip] Sprint board
+> - Actualizar en [[SprintBoard/{{tp_title}}|SprintBoard]]
+> - Documentar entregables en carpeta `/deploy`
+
+```dataview
+TABLE milestone as "Entregable", due, owner, status
+FROM ""
+WHERE stage = "deploy" and project = this.file.name
+SORT due asc
+```
+
+> [!todo]- Checklist sostenibilidad operativa
+> - [ ] Energía 100% renovable en despliegue
+> - [ ] Métricas de emisión monitorizadas
+> - [ ] Plan de remediación documentado
+
+```button
+name Abrir bitácora diaria
+type command
+action QuickAdd: Nueva bitácora
+```
+
+---
+
+## 4. Sustain
+
+> [!note]- Métricas vivas
+> ```tracker
+> searchType: frontmatter
+> searchTarget: impact_carbon_actual
+> datasetName: Carbono actual
+> line:
+>   title: "Kg CO₂ eq"
+>   color: "#3B8D4E"
+> ```
+>
+> ```tracker
+> searchType: frontmatter
+> searchTarget: satisfaction_index
+> datasetName: Satisfacción
+> line:
+>   title: "Índice"
+>   color: "#1F6FEB"
+> ```
+
+```dataview
+LIST from "" WHERE stage = "sustain" and type = "learning" and project = this.file.name
+```
+
+> [!bug]- Alertas activas (Tasks)
+> ```tasks
+> not done
+> path includes {{tp_title}}
+> tag includes #alerta
+> ```
+
+---
+
+## 5. Feedback & aprendizajes
+
+> [!summary]- Retroalimentación de stakeholders
+> - `{{DATE:YYYY-MM-DD}}` — `@persona`: <feedback>
+> - `{{DATE:YYYY-MM-DD}}` — `@persona`: <feedback>
+
+```dataview
+TABLE reviewer as "Revisor", decision as "Decisión", notes as "Notas"
+FROM ""
+WHERE type = "review" and project = this.file.name
+SORT date desc
+```
+
+> [!quote]- Compromiso ORBIT
+> "No hay despliegue sin evidencia de impacto positivo neto."
+
+---
+
+## 6. OutputTemplate y próximos pasos
+
+```yaml
+OutputTemplate:
+  deliverable: ProjectMasterRecord
+  exports:
+    - format: markdown
+    - format: json
+    - format: pdf
+  validations:
+    - name: Tasks plugin
+      command: Tasks: Create or update checklist
+    - name: Linter
+      command: Linter: Lint current file
+  follow_up:
+    cadence: {{VALUE:review_cadence?P14D}}
+    owner: {{VALUE:owner?"@pending"}}
+```

--- a/templates/master_template_proposals/obsidian_master_template_proposal_spectrum.md
+++ b/templates/master_template_proposals/obsidian_master_template_proposal_spectrum.md
@@ -1,0 +1,192 @@
+---
+asset:
+  id: obsidian_master_template_spectrum_2025_09
+  name: ObsidianMasterTemplateSpectrum
+  version: 0.1.1
+  owner: AingZ_Platform
+  status: draft
+context:
+  dom: KnowledgeSystems
+  goals:
+    - curate_multidisciplinary_knowledge
+    - maintain_traceable_evidence
+  risks:
+    - reference_drift
+    - knowledge_fragmentation
+compat:
+  platforms: [Obsidian, GPT5, CODEX]
+  connectors: [GitHub, Zotero, GoogleDrive]
+  notes: "Diseñado para vaults con fuerte componente de investigación."
+obsidian:
+  cssclass: layout-widescreen
+  required_plugins: [Dataview, Excalidraw, Canvas, Buttons, DataviewJS, Linter, StyleSettings, Admonition]
+  recommended_dataview_version: ">=0.5.68"
+---
+
+# {{VALUE:entry_title?Ficha de conocimiento}}
+
+> [!abstract] Snapshot
+> **Tema**: `<topic>` · **Dominios**: `<dominios>` · **Nivel de confianza**: `<confidence>%`
+>
+> - Última revisión: {{DATE:YYYY-MM-DD}}
+> - Estado: `<status>`
+> - Guardián: `@guardian`
+
+---
+
+## 1. Front-matter extendido (Properties)
+
+```yaml
+aliases: [<alias1>, <alias2>]
+source_primary: <fuente principal>
+source_type: [paper|repo|nota]
+relevance_score: <0-100>
+confidence: <0-100>
+impact_axes: [ambiental, social, económico]
+related_canvas: {{VALUE:entry_title?Ficha de conocimiento}}.canvas
+related_excalidraw: {{VALUE:entry_title?Ficha de conocimiento}}.excalidraw
+```
+
+---
+
+## 2. Mapa cognitivo
+
+> [!map]- Visualizaciones clave
+> - Canvas :: `![[{{VALUE:entry_title?Ficha de conocimiento}}.canvas]]`
+> - Excalidraw :: `![[{{VALUE:entry_title?Ficha de conocimiento}}.excalidraw]]`
+> - Grafo local :: `[[=this.file.path]]`
+
+```dataviewjs
+const neighbors = dv.current().file.outlinks.concat(dv.current().file.inlinks);
+const counts = {};
+neighbors.forEach(link => {
+  const path = link.path;
+  counts[path] = (counts[path] ?? 0) + 1;
+});
+const rows = Object.entries(counts).map(([path, weight]) => ({
+  note: dv.fileLink(path),
+  weight
+})).sort((a, b) => b.weight - a.weight);
+dv.table(["Nota relacionada", "Peso"], rows.slice(0, 10));
+```
+
+---
+
+## 3. Contenido nuclear
+
+> [!summary]- TL;DR
+> - Insight 1 :: <texto>
+> - Insight 2 :: <texto>
+> - Insight 3 :: <texto>
+
+### Contexto ampliado
+
+```ad-note
+title: Origen del conocimiento
+type: bookmark
+collapse: closed
+```
+> - Fuente primaria: <cita>
+> - Fecha de publicación: <año>
+> - Licencia: <tipo>
+
+### Detalle técnico (RAW)
+
+```ad-example
+title: Evidencia clave
+collapse: open
+```
+> - Punto de datos A: <detalle>
+> - Punto de datos B: <detalle>
+> - Modelos asociados: <modelo>
+
+```ad-info
+title: Riesgos y límites
+collapse: open
+```
+> - Riesgo 1: <detalle>
+> - Riesgo 2: <detalle>
+> - Gap: <detalle>
+
+---
+
+## 4. DO / DON'T operacional
+
+> [!check]- DO
+> - Aplicar en proyectos con <condición>
+> - Mantener trazas en `WK.log`
+> - Validar métricas de impacto antes de escalar
+
+> [!failure]- DON'T
+> - Usar sin validación de contexto
+> - Compartir sin limpiar datos sensibles
+> - Desalinear nomenclatura del glosario V5
+
+---
+
+## 5. Evidencias y bibliografía
+
+```dataview
+TABLE source as "Fuente", type as "Tipo", year, access, reliability
+FROM ""
+WHERE type = "reference" and topic = this.file.name
+SORT reliability desc
+```
+
+> [!tip]- Sincronización Zotero
+> ```button
+> name Importar desde Zotero
+> type command
+> action MetaEdit: Zotero Import
+> ```
+
+```dataviewjs
+const bib = dv.pages().where(p => p.collection == "bibliography" && p.topics && p.topics.includes(dv.current().file.name));
+dv.list(bib.map(b => `${b.file.link} — ${b.authors ?? "s.d."} (${b.year ?? "s.f."})`));
+```
+
+---
+
+## 6. Aprendizajes y próximos pasos
+
+> [!note]- WK.log
+> ```yaml
+> wk_entry:
+>   when: {{DATE:YYYY-MM-DDTHH:mm}}
+>   actor: ai|human
+>   connector: <GitHub/Zotero>
+>   findings:
+>     - <aprendizaje>
+>   next:
+>     - <acción>
+> ```
+
+```tasks
+not done
+path includes {{VALUE:entry_title?Ficha de conocimiento}}
+tag includes #knowledge/todo
+```
+
+> [!todo]- Próximos pasos sugeridos
+> - [ ] Validar con experto dominio `@persona`
+> - [ ] Actualizar indicadores de impacto
+> - [ ] Subir resumen a repositorio público
+
+---
+
+## 7. OutputTemplate
+
+```yaml
+OutputTemplate:
+  deliverable: KnowledgeMasterRecord
+  exports:
+    - format: markdown
+    - format: json
+    - format: opml
+  validation:
+    - command: Dataview: Force refresh current view
+    - command: Linter: Lint current file
+  review:
+    owner: {{VALUE:guardian?"@pending"}}
+    cadence: P30D
+```


### PR DESCRIPTION
## Summary
- map the existing markdown landscape to extract template requirements for Obsidian alignment
- add three master template proposals (Nexus, Orbit, Spectrum) leveraging Obsidian interactivity features
- index the proposals and evaluation criteria for selecting the new standard

## Testing
- no tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d547789d6083299e92f88911f8c32b