### PR TITLE
Publish Orbit·Spectrum V1 master template

### DIFF
--- a/templates/master_template_proposals/README.md
+++ b/templates/master_template_proposals/README.md
@@ -1,0 +1,63 @@
+---
+asset:
+  id: obsidian_master_template_catalog_2025_09
+  name: ObsidianMasterTemplateCatalog
+  version: 1.0.0
+  owner: AingZ_Platform
+  status: validated
+context:
+  domain: KnowledgeArchitecture
+  goals:
+    - centralize_validated_master_template
+    - document_usage_contracts
+  risks:
+    - drift_against_ruleset
+    - loss_of_interactive_blocks
+compat:
+  platforms: [Obsidian, VSCode, GitHub]
+  connectors: [Codex, GPT5]
+  notes: "Este índice refleja únicamente la versión validada del master template."
+---
+
+# Master Template Orbit·Spectrum V1 (Validado)
+
+- **Plantilla activa:** [[obsidian_master_template_aingz_master|A·Master Template · Orbit-Spectrum V1]]
+- **Última revisión:** <% tp.date.now('YYYY-MM-DD') %>
+- **Responsable de curaduría:** Equipo híbrido (AI Codex/GPT5 + humanos AingZ)
+
+> [!summary] ¿Por qué se consolidó esta versión?
+> - Integra el análisis de assets del repositorio y el legado curado en [[legacy_reference_pool/README|Legacy Reference Pool]].
+> - Maximiza interactividad Obsidian (Buttons, Dataview, Tasks, Tracker, Canvas, wikilinks).
+> - Contiene contratos explícitos para Codex y GPT5, garantizando reproducibilidad en múltiples plataformas (VSCode, GitHub, Obsidian).
+
+---
+
+## Cómo utilizar la plantilla
+
+1. Ejecutar `QuickAdd → MT · Nueva Nota` o `Templater → Insert template → A·Master Template · Orbit-Spectrum V1`.
+2. Completar la cabecera YAML antes de editar el cuerpo.
+3. Seguir las instrucciones en [[obsidian_master_template_aingz_master#00 · Setup Rápido]].
+4. Documentar cualquier personalización en [[obsidian_master_template_aingz_master#50 · Feedback y WK.log]] y, si aplica, anexar evidencia al [[legacy_reference_pool/README|Legacy Reference Pool]].
+
+> [!warning] Bloques protegidos
+> No eliminar callouts, botones, queries ni checklists definidos en la plantilla. Son necesarios para la colaboración AI↔humano.
+
+---
+
+## Mantenimiento y evolución
+
+- Cualquier ajuste mayor debe registrarse como propuesta en `legacy_reference_pool` antes de actualizar la versión validada.
+- Seguir los KPIs definidos en [[assets_landscape_analysis.md#7-kpi-propuestos-para-evaluar-adopción|KPIs de adopción]] para medir efectividad.
+- Cuando se valide una nueva iteración, actualizar este índice y mover la versión previa al repositorio histórico.
+
+---
+
+## Recursos vinculados
+
+| Recurso | Descripción | Uso |
+| ------- | ----------- | --- |
+| [[assets_landscape_analysis.md]] | Análisis integral de assets Markdown | Identificar requisitos y KPIs.
+| [[obsidian_master_template_aingz_master]] | Plantilla validada | Base obligatoria para nuevas notas.
+| [[legacy_reference_pool/README]] | Referencias históricas | Consultar experimentos y reglas previas.
+
+> [!tip] Mantén sincronizado este índice con GitHub y Obsidian para que Codex/GPT5 accedan siempre a la versión oficial.

--- a/templates/master_template_proposals/assets_landscape_analysis.md
+++ b/templates/master_template_proposals/assets_landscape_analysis.md
@@ -1,0 +1,81 @@
+---
+asset:
+  id: repo_asset_landscape_obsidian_2025_09
+  name: ObsidianAssetLandscape
+  version: 1.1.0
+  owner: AingZ_Platform
+  status: validated
+context:
+  dom: KnowledgeArchitecture
+  goals:
+    - map_existing_markdown_assets
+    - derive_requirements_for_master_template
+  risks:
+    - outdated_contracts
+    - inconsistent_front_matter
+compat:
+  platforms: [Obsidian, GPT5, CODEX]
+  connectors: [GitHub]
+  notes: "Actualizado tras validar el master template Orbit·Spectrum V1."
+---
+
+# Panorama de assets Markdown vigentes
+
+> Objetivo: obtener una visión holística de los artefactos activos para fundamentar un nuevo master template compatible con Obsidian y los lineamientos V5.
+
+## 1. Baselines bloqueados
+
+| Ruta | Propósito | Observaciones clave |
+| ---- | --------- | ------------------- |
+| `core/doc/workbench/AINGZ_V5_Baselines_Unificados_v1_4_1_locked.md` | Consolidado normativo V5 | Define taxonomía y nomenclaturas, sirve como contrato fuente para semántica y jerarquías operativas. |
+| `core/doc/workbench/ruleset_baseline_v_1_locked.md` | RULESET base | Enfatiza contratos claros, unicidad de IDs y estructuras modulares RULE/SPEC/ENV/PRC. |
+| `core/doc/workbench/glossary_baseline_v_1_locked.md` | Glosario | Garantiza semántica única con definiciones inmutables, imprescindible para properties en Obsidian. |
+
+## 2. Rulesets y contratos activos
+
+- `ruleset/ruleset_master_v_1.md` establece las políticas unificadas para plataformas GPT, Codex, GitHub y Obsidian, incluyendo requisitos de front‑matter y OutputTemplate obligatorio.
+- `aing_z_ruleset_max_universal_v_1_0_template.md` codifica el contrato universal con cabecera YAML y jerarquía RULE/SPEC/ENV/PRC, reforzando evidencias, trazabilidad y seguridad.
+
+## 3. Knowledge packs y contextos operativos
+
+| Asset | Rol | Oportunidades para el master template |
+| ----- | --- | ------------------------------------- |
+| `chat_gpt_plus_knowledge_context_pack_v_1.md` | Paquete de contexto rápido | Estructura ligera con secciones de contexto y prompts; útil para callouts de misión y DO/DON'T. |
+| `codex_knowledge_context_pack_literal.md` | Contexto literal | Contiene enumeraciones y snippets reutilizables, ideal para secciones plegables (`> [!example]`) en la plantilla. |
+| `kb_obsidian_plugins_core_community_unificado_v_2025_09_02.md` | Inventario Obsidian | Lista plugins core/community activos, habilita uso de Dataview, Buttons, Tracker, Templater y Canvas como elementos soportados. |
+
+## 4. Recursos operativos complementarios
+
+- `test_suite_obsidian_plugins_core_community_v_1.md` documenta verificaciones sugeridas para plugins, relevante para checklists automatizadas.
+- `ruleset/context_pack_index.md` inventaría context packs y minipacks, mostrando conveniencia de tablas índice y enlaces cruzados.
+- `main/data_base` replica baselines en modo distribuido (`glossary`, `dir_tree`, `core_actv`), indicando necesidad de queries Dataview o `dataviewjs` para sincronización ligera dentro del vault.
+
+## 5. Requisitos derivados para el nuevo master template
+
+1. **Front‑matter estricto**: campos `asset`, `context`, `compat` alineados con RULESET_MAX.
+2. **Interactividad Obsidian**: compatibilidad con callouts, Tabs (cssclass), Dataview, Buttons y Canvas embeds.
+3. **Contratos visibles**: secciones para Inputs/Outputs, checkpoints y logging (`WK.log`).
+4. **Modos de vista**: bloques plegables para modo Focus, Resumen ejecutivo y Detalle técnico.
+5. **Instrumentación KPI**: tablas dinámicas y trackers para métricas de sostenibilidad e impacto.
+
+## 6. Master template validado
+
+- Plantilla oficial: [[obsidian_master_template_aingz_master]] (`status: validated`).
+- Origen: integración de aprendizajes de `legacy_reference_pool` + propuestas Orbit/Spectrum.
+- Diferenciadores clave:
+  - Contrato AI↔humano explícito (sección [[obsidian_master_template_aingz_master#01 · AI ↔ Humano Handshake]]).
+  - Interactividad ampliada (Buttons, Dataview, Tasks, Tracker, Canvas placeholders) con wikilinks para navegación Obsidian.
+  - KPIs y sostenibilidad incorporados en [[obsidian_master_template_aingz_master#40 · Impacto & Sostenibilidad]].
+
+## 7. KPI propuestos para evaluar adopción
+
+| KPI | Descripción | Métrica asociada |
+| --- | ----------- | ---------------- |
+| `TemplateCoverage` | % de notas nuevas que usan el master template | `#NotasTemplate / #NotasNuevas` (Dataview). |
+| `InteractionDepth` | Promedio de componentes interactivos utilizados por nota | Conteo de callouts, tasks y embeds. |
+| `SustainabilityTrace` | Notas con properties de impacto ambiental completadas | `dv.pages().where(p => p.impact_carbon)` |
+| `FeedbackLoopTime` | Tiempo desde creación a primera retroalimentación registrada | `date(first_feedback) - date(created)`. |
+
+---
+
+> Próximo paso: monitorear KPIs, registrar insights en `legacy_reference_pool` y, si es necesario, preparar una nueva propuesta para revisión formal.

--- a/templates/master_template_proposals/legacy_reference_pool/README.md
+++ b/templates/master_template_proposals/legacy_reference_pool/README.md
@@ -1,0 +1,26 @@
+# Legacy Reference Pool for Master Templates
+
+Este contenedor centraliza materiales históricos, reglas previas y artefactos de soporte relacionados con el desarrollo de los master templates y RULESET.
+
+## Propósito
+- Facilitar la consulta incremental sin reanalizar todo el repositorio.
+- Versionar lineamientos, experimentos y ejemplos relevantes para la evolución de la plantilla maestra.
+- Servir como punto de carga de anexos (`.md`, `.json`, `.canvas`, `.excalidraw`, etc.) que deban incorporarse en futuras iteraciones.
+
+## Convenciones de carga
+1. **Naming**: `YYYYMMDD_contexto_descripcion.md` (adaptar extensión según corresponda).
+2. **Frontmatter recomendado**:
+   ```yaml
+   legacy_ref: true
+   scope: [template, ruleset]
+   source: <origen>
+   notes: <detalle breve>
+   ```
+3. **Referencias cruzadas**: incluir enlaces de retorno hacia la versión activa del master template o al RULESET vigente.
+4. **Control de cambios**: resumir en la parte superior qué conocimiento aporta y si reemplaza documentos previos.
+
+## Workflow sugerido
+- Al incorporar nuevo material, registrar un breve changelog en `templates/master_template_proposals/README.md` dentro de la sección de notas futuras.
+- Utilizar este folder como staging para insights que la IA (Codex / ChatGPT) y el equipo humano puedan incorporar en sesiones de co-diseño.
+
+> Mantener el contenido curado y etiquetado para habilitar búsquedas rápidas desde Dataview (`WHERE legacy_ref = true`).

--- a/templates/master_template_proposals/obsidian_master_template_aingz_master.md
+++ b/templates/master_template_proposals/obsidian_master_template_aingz_master.md
@@ -1,0 +1,247 @@
+---
+asset:
+  id: "<% tp.date.now('YYYYMMDDHHmm') %>_<% tp.file.title.replace(/\s+/g, '_').toUpperCase() %>"
+  name: "<% tp.file.title %>"
+  type: master_template
+  version: "1.0.0"
+  owner: "AingZ_Platform"
+  status: "validated"
+  tags:
+    - obsidian/master
+    - ai-collab
+    - sustainability
+  created: "<% tp.date.now('YYYY-MM-DD') %>"
+  updated: "<% tp.date.now('YYYY-MM-DD') %>"
+context:
+  domain: ""
+  mission: ""
+  goals:
+    - ""
+  stakeholders:
+    - role: ""
+      contact: ""
+  risks:
+    - ""
+compat:
+  platforms: ["Obsidian", "VSCode", "GitHub", "Codex", "GPT5"]
+  plugins:
+    required: ["Dataview", "Templater", "Buttons", "QuickAdd", "Tracker", "Tasks", "Calendar"]
+    optional: ["Canvas", "Excalidraw", "Projects", "BRAT", "Periodic Notes"]
+  notes: "Duplicar con Templater/QuickAdd antes de editar."
+ai_handshake:
+  codex:
+    mode: "structured_markdown"
+    output_contract: "Mantener YAML, callouts y bloques interactivos intactos."
+    prompts:
+      - "Responder con listas accionables"
+      - "Actualizar checklists y WK.log al final de cada intervención"
+  gpt5:
+    mode: "reasoning_markdown"
+    output_contract: "Explicar decisiones en [[#50 · Feedback y WK.log]] con timestamp."
+    prompts:
+      - "Aplicar análisis sistémico con perspectiva de sostenibilidad"
+      - "Proponer optimizaciones cuantificables (KPIs)"
+governance:
+  ruleset: "[[ruleset/ruleset_master_v_1]]"
+  reference_legacy: "[[templates/master_template_proposals/legacy_reference_pool/README|Legacy Reference Pool]]"
+  change_control: "Registrar decisiones estratégicas en [[#50 · Feedback y WK.log]]."
+---
+
+%% -------------------------------------------------------------
+%% Guía rápida: la IA (Codex / GPT5) y los humanos deben seguir
+%% estas instrucciones sin eliminar bloques estructurales.
+%% -------------------------------------------------------------
+
+# [[A·Master Template · Orbit-Spectrum V1]]
+
+> [!summary] Navegación inmediata
+> [[#00 · Setup Rápido]] · [[#01 · AI ↔ Humano Handshake]] · [[#02 · Contratos y Metadata]] · [[#10 · Contexto Estratégico]] · [[#20 · Flujo Operativo]] · [[#30 · Data & Inteligencia]] · [[#40 · Impacto & Sostenibilidad]] · [[#50 · Feedback y WK.log]] · [[#60 · Anexos & Referencias]] · [[#99 · Checklist de Cierre]]
+
+---
+
+## 00 · Setup Rápido
+
+> [!abstract]+ Activación inicial
+> 1. Renombrar la nota siguiendo `YYYYMMDD_<TemaClave>`.
+> 2. Ejecutar la acción QuickAdd `MT · Nueva Nota` para clonar propiedades comunes.
+> 3. Validar que los campos de [[#02 · Contratos y Metadata]] estén completos.
+
+```button
+name ➕ Instanciar Plantilla Hija
+type command
+action QuickAdd:MT · Nueva Nota Hija
+color blue
+```
+
+```button
+name ♻️ Refrescar Dataview
+type command
+action Dataview:Refresh current view
+color purple
+```
+
+- [ ] Confirmar que `ai_handshake` contiene las instrucciones vigentes.
+- [ ] Registrar responsables en `context.stakeholders`.
+- [ ] Sincronizar tags con la taxonomía del [[ruleset/ruleset_master_v_1]].
+
+> [!hint] Ajusta el campo `action` de cada botón según los IDs de comando disponibles en tu vault (`Settings → Buttons`).
+
+---
+
+## 01 · AI ↔ Humano Handshake
+
+> [!info] Codex
+> - Interpretar secciones tituladas con `##` como módulos independientes.
+> - No modificar frontmatter salvo que se solicite explícitamente.
+> - Documentar comandos ejecutados dentro de [[#50 · Feedback y WK.log]].
+
+> [!tip] GPT5
+> - Mantener trazabilidad de decisiones en subtareas `- [ ]` y justificar cambios significativos.
+> - Antes de cerrar, completar el bloque [[#99 · Checklist de Cierre]] con hallazgos clave.
+
+> [!warning] Bloques protegidos
+> - No eliminar los bloques `button`, `dataview`, `tasks`, `tracker` ni las secciones con `%%`.
+> - Respetar los wikilinks internos (`[[#Sección]]`) para asegurar navegabilidad en Obsidian.
+
+---
+
+## 02 · Contratos y Metadata
+
+> [!todo]+ Campos obligatorios (RULESET)
+> - `asset.domain`, `context.mission`, `compat.platforms`
+> - `governance.ruleset`, `governance.change_control`
+> - `ai_handshake` actualizado según el modo de colaboración.
+
+| Campo | Descripción | Estado |
+| ----- | ----------- | ------ |
+| `mission` | Objetivo operativo principal | - [ ] |
+| `goals` | Metas cuantificables vinculadas a KPIs | - [ ] |
+| `risks` | Riesgos críticos con planes de mitigación | - [ ] |
+| `stakeholders` | Roles clave y responsables | - [ ] |
+
+> [!note] Sincronización automática
+> Usa el botón `♻️ Refrescar Dataview` tras editar frontmatter para actualizar paneles derivados.
+
+---
+
+## 10 · Contexto Estratégico
+
+> [!quote] Narrativa
+> Resume el propósito, alcance y horizonte temporal del asset.
+
+> [!example]- Modo Ejecutivo
+> - Hito clave #1: _...
+> - Dependencias críticas: _...
+> - KPIs vinculados: `TemplateCoverage`, `InteractionDepth`.
+
+> [!faq]- Modo Profundo (plegable)
+> - ¿Qué supuestos guían este trabajo?
+> - ¿Cómo se relaciona con [[legacy_reference_pool/README|Legacy Reference Pool]]?
+> - ¿Qué recursos adicionales se necesitan?
+
+---
+
+## 20 · Flujo Operativo
+
+> [!todo]+ Stage Gates
+> 1. **Discovery** → [[#30 · Data & Inteligencia]]
+> 2. **Design** → prototipos en Canvas/Excalidraw (`![[canvas/<% tp.file.title %>.canvas]]`)
+> 3. **Delivery** → tareas operativas en lista siguiente
+> 4. **Sustain** → validación de KPIs y documentación final
+
+### 20.1 · Plan de tareas
+
+- [ ] Discovery · Investigación preliminar (responsable: )
+- [ ] Design · Construcción de solución (responsable: )
+- [ ] Delivery · Implementación / despliegue (responsable: )
+- [ ] Sustain · Seguimiento y ajustes (responsable: )
+
+```tasks
+not done
+path includes <% tp.file.title %>
+short mode
+group by filename
+sort by priority
+```
+
+> [!tip] Usa `QuickAdd` para crear subtareas siguiendo la convención `YYYYMMDD · Acción · Responsable`.
+
+---
+
+## 30 · Data & Inteligencia
+
+> [!info] Tablero Dataview
+> Visualiza notas relacionadas que comparten el mismo tag o `asset.id`.
+
+```dataview
+TABLE file.mtime as "Última edición", mission, status, impact_carbon
+FROM ""
+WHERE contains(file.tags, "obsidian/master") AND file.name != this.file.name
+SORT file.mtime DESC
+```
+
+> [!hint]- Integración externa
+> - Embed datasets relevantes: `![[data/<nombre_dataset>.csv]]`
+> - Usa `dataviewjs` para cálculos personalizados si se requieren métricas avanzadas.
+
+---
+
+## 40 · Impacto & Sostenibilidad
+
+> [!todo]+ Indicadores principales
+> - `impact_carbon` (kg CO2e)
+> - `impact_water` (L)
+> - `impact_social` (breve descripción)
+
+```tracker
+searchType: dvField
+searchTarget: impact_carbon
+datasetName: "Huella de Carbono"
+accumulation: sum
+startDate: <% tp.date.now('YYYY-MM-01') %>
+endDate: <% tp.date.now('YYYY-MM-DD') %>
+lineChart:
+    title: "Tendencia mensual"
+```
+
+> [!warning] Si algún indicador supera el umbral pactado en [[ruleset/ruleset_master_v_1]], activar plan de mitigación y documentarlo en [[#50 · Feedback y WK.log]].
+
+---
+
+## 50 · Feedback y WK.log
+
+> [!note] Registrar cada intervención de IA/humano con timestamp ISO8601.
+
+| Fecha/Hora | Autor | Rol | Resumen | Próximo paso |
+| ---------- | ----- | --- | ------- | ------------- |
+| <% tp.date.now('YYYY-MM-DDTHH:mm') %> |  |  |  |  |
+
+> [!todo]- Retroalimentación pendiente
+> - [ ] Validar entregables con responsables humanos
+> - [ ] Documentar aprendizajes clave en RULESET o Legacy si aplica
+
+---
+
+## 60 · Anexos & Referencias
+
+> [!tip] Recursos vinculados
+> - [[ruleset/ruleset_master_v_1]] (contrato vigente)
+> - [[aing_z_ruleset_max_universal_v_1_0_template]]
+> - [[templates/master_template_proposals/legacy_reference_pool/README|Legacy Reference Pool]]
+> - ![[canvas/<% tp.file.title %> · mapa.canvas]] *(crear si se necesita visualización)*
+
+> [!example]- Evidencias multimedia
+> - Capturas: `![[evidence/<% tp.date.now('YYYYMMDD') %>_screenshot.png]]`
+> - Audio/Video: `![[evidence/<% tp.date.now('YYYYMMDD') %>_brief.mp4]]`
+
+---
+
+## 99 · Checklist de Cierre
+
+- [ ] WK.log actualizado y compartido
+- [ ] KPIs revisados y en rango
+- [ ] Feedback integrado al [[templates/master_template_proposals/legacy_reference_pool/README|Legacy Reference Pool]] si aplica
+- [ ] Estado final comunicado (Codex/GPT5 + humano)
+- [ ] Nota archivada o marcada como `status: completed`
+
+> [!success] Cuando todos los checks estén completos, actualizar `asset.status` a `completed` y mover la nota al archivo correspondiente.


### PR DESCRIPTION
## Summary
- replace the exploratory Nexus/Orbit/Spectrum drafts with the validated Orbit·Spectrum V1 master template including AI handshake guidance, interactive components, and sustainability trackers
- update the master template index to reference the consolidated template and provide usage, maintenance, and legacy integration guidance
- refresh the asset landscape analysis to reflect the validated template and clarify the follow-up workflow

## Testing
- no automated tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d547789d6083299e92f88911f8c32b