### PR TITLE
Clarify template context navigation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,35 @@ Repositorio base para la implementación de la arquitectura V5. Mantiene los bas
 - `V5/` – plantillas y minipacks oficiales para generar artefactos.
 - `legacy/` – material heredado pendiente de migración o archivado.
 - `ruleset/` – bucket central con el ruleset maestro y sus referencias.
+- `templates/` – punto de entrada para los formularios maestros (documentación operativa y arquitectura).
+
+## Ruta de contexto para nuevas sesiones
+
+> [!summary] Inicio rápido para IA (Codex/GPT5) y humanos
+> 1. **Reglas y contratos** → lee el [Ruleset maestro](ruleset/ruleset_master_v_1.md) para alinear modos de colaboración.
+> 2. **Master template validado** → sigue `templates/master_template_proposals/README.md` y aplica [[templates/master_template_proposals/obsidian_master_template_aingz_master.md|A·Master Template · Orbit-Spectrum V1]].
+> 3. **Context pack operativo** → carga [[templates/master_template_proposals/context_packages/orbit_spectrum_master_template_context_pack_v1.md]] para recuperar acuerdos y dependencias previas.
+> 4. **Arquitectura** → usa `templates/architecture_interactive_forms/README.md` para seleccionar el formulario adecuado.
+> 5. **Dir Tree + Excalidraw** → trabaja con [[templates/architecture_interactive_forms/dir_tree_creator_form.md]] como baseline sincronizado Mermaid/Excalidraw.
+> 6. **Legacy de soporte** → consulta `templates/master_template_proposals/legacy_reference_pool/README.md` y `templates/architecture_interactive_forms/legacy_reference_pool/README.md` para evitar releer el repositorio completo.
 
 ## Reglas generales
 1. Los baselines bloqueados residen en `core/doc/workbench` y son la fuente de verdad.
 2. Toda nueva documentación debe incluir front‑matter válido y un OutputTemplate explícito.
 3. `wf_playbooks` reemplaza a `wf_template` en la estructura V5.
+4. Respetar los bloques interactivos protegidos de las plantillas (Buttons, Dataview, Tasks, Tracker) para mantener la colaboración IA↔humana.
 
-Para obtener lineamientos unificados de todas las plataformas (ChatGPT, Codex, VSCode, GitHub, Obsidian, Excalidraw), consultar el [Ruleset maestro](ruleset/ruleset_master_v_1.md).
+## Formularios clave y recursos
+
+| Ruta | Propósito | Notas |
+| ---- | --------- | ----- |
+| `templates/master_template_proposals/README.md` | Índice del master template validado y propuestas Next Gen. | Mantiene contratos Codex/GPT5 y lineamientos de adopción. |
+| `templates/architecture_interactive_forms/README.md` | Guía de formularios de arquitectura. | Incluye integración con Excalidraw y KPIs de arquitectura. |
+| `templates/architecture_interactive_forms/obsidian_architecture_master_form.md` | Formulario maestro para diseñar y auditar arquitectura. | Usa Tabs, Buttons, Dataview y WK.log. |
+| `templates/architecture_interactive_forms/dir_tree_creator_form.md` | Blueprint de árboles de directorios con Mermaid + Excalidraw. | Baseline oficial para evolucionar el dir tree. |
+| `templates/architecture_interactive_forms/architecture_assets_inventory.md` | Inventario de assets y árboles actuales. | Referencia rápida para auditorías y asignación de owners. |
+| `templates/master_template_proposals/legacy_reference_pool/README.md` | Pool de decisiones y reglas históricas del master template. | Registra experimentos y acuerdos previos. |
+| `templates/architecture_interactive_forms/legacy_reference_pool/README.md` | Legacy para formularios de arquitectura. | Adjunta snapshots, evidencias y feedback. |
 
 ## Output Template
 ```markdown

--- a/templates/architecture_interactive_forms/README.md
+++ b/templates/architecture_interactive_forms/README.md
@@ -1,0 +1,23 @@
+# Arquitectura · Formularios Interactivos
+
+Este paquete concentra formularios y plantillas operativas para diseñar, validar y mantener la arquitectura integral de la plataforma AingZ.
+
+## Contenido
+
+- `obsidian_architecture_master_form.md` · Formulario maestro con integración a Excalidraw y bloques interactivos para ciclos de diseño y retroalimentación.
+- `dir_tree_creator_form.md` · Formulario especializado para definir y versionar árboles de directorios con blueprint Mermaid y sincronía Excalidraw.
+- `architecture_assets_inventory.md` · Inventario de referencia con los assets y árboles de directorios relevantes del repositorio actual.
+- `legacy_reference_pool/` · Carpeta para anexar decisiones, snapshots y evidencias asociadas a los formularios de arquitectura.
+
+## Uso recomendado
+
+1. Duplica `obsidian_architecture_master_form.md` mediante QuickAdd/Templater para cada arquitectura o repositorio que necesite documentación.
+2. Completa el formulario sección por sección y utiliza los botones para abrir o generar diagramas en Excalidraw.
+3. Registra decisiones y pendientes dentro de las listas de tareas y el bloque de WK.log para mantener trazabilidad.
+4. Utiliza `dir_tree_creator_form.md` para detallar jerarquías específicas y mantener sincronizados Mermaid/Excalidraw.
+5. Consulta `architecture_assets_inventory.md` para ubicar rápidamente assets, reglas y plantillas vinculadas.
+6. Registra anexos o decisiones históricas dentro de `legacy_reference_pool/` para acelerar futuras iteraciones.
+
+> [!tip] Integración Obsidian
+> Habilita los plugins **Excalidraw**, **Dataview**, **Buttons**, **Tasks** y **Templater** para aprovechar todo el comportamiento interactivo del formulario.
+

--- a/templates/architecture_interactive_forms/architecture_assets_inventory.md
+++ b/templates/architecture_interactive_forms/architecture_assets_inventory.md
@@ -1,0 +1,54 @@
+asset_id: "inventory_architecture_assets_v1"
+asset_type: "knowledge_base"
+asset_version: "1.0.0"
+asset_owner: "AingZ_Platform"
+asset_status: "active"
+asset_tags:
+  - architecture
+  - inventory
+  - obsidian/reference
+asset_updated: "2024-09-30"
+---
+
+# Inventario de Assets · Arquitectura Plataforma AingZ
+
+> [!info] Propósito
+> Proporcionar un mapa rápido de carpetas, plantillas y artefactos clave para orquestar la arquitectura de plataforma dentro del repositorio `AingZ_Platform`.
+
+## Directorios raíz relevantes
+
+| Carpeta | Enfoque | Notas clave |
+| ------- | ------- | ----------- |
+| `core/` | Documentación y workbench operativos | Contiene cuadernos de trabajo en `doc/workbench` y artefactos bloqueados para baseline V5. |
+| `legacy/` | Historial y versiones previas | Útil para rastrear evoluciones de reglas y plantillas. |
+| `main/` | Activos funcionales actuales | Incluye implementaciones y configuraciones en curso. |
+| `new_repo_pack/` | Paquetes de arranque | Base para generar nuevos repositorios alineados a la metodología AingZ. |
+| `ruleset/` & `ruleset_pack_v1/` | Normativas vigentes | Reglas y contratos maestros que gobiernan plantillas y operaciones. |
+| `templates/master_template_proposals/` | Plantillas maestras validadas | Aloja el Orbit·Spectrum V1 y el Legacy Reference Pool asociado. |
+| `V5/` | Material específico de la versión 5 | Incluye planes (`TREE_PLAN`, `SWEEP_PLAN`) y artefactos estratégicos. |
+| `scripts/` | Automatizaciones y utilidades | Scripts de soporte para workflows técnicos. |
+
+## Artefactos destacados
+
+- `platform_arch_v5.excalidraw` · Mapa visual de arquitectura actual, ideal para enlazar desde formularios interactivos.
+- `codex_chatgpt5_config.md` · Configuración de colaboración entre modelos Codex/GPT5.
+- `aing_z_ruleset_max_universal_v_1_0_template.md` · Referencia extendida de reglas universales.
+- `templates/master_template_proposals/obsidian_master_template_aingz_master.md` · Master template validado Orbit·Spectrum V1.
+- `templates/master_template_proposals/legacy_reference_pool/README.md` · Índice de referencias históricas para iteraciones futuras.
+
+## Vínculos sugeridos
+
+- `[[ruleset/ruleset_master_v_1]]`
+- `[[templates/master_template_proposals/obsidian_master_template_aingz_master|Orbit·Spectrum V1]]`
+- `[[templates/master_template_proposals/legacy_reference_pool/README|Legacy Reference Pool]]`
+- `![[platform_arch_v5.excalidraw]]`
+
+## Próximos pasos
+
+- [ ] Actualizar este inventario al incorporar nuevos repositorios satélite.
+- [ ] Añadir referencias a dashboards o monitoreo externo (Grafana/Prometheus) cuando estén disponibles.
+- [ ] Enlazar decisiones registradas en `obsidian_architecture_master_form` una vez activado.
+
+> [!tip] Dataview
+> Convierte esta nota en panel navegable con `TABLE file.link, asset_status WHERE contains(asset_tags, "architecture")` para listar rápidamente todos los formularios activos.
+

--- a/templates/architecture_interactive_forms/dir_tree_creator_form.md
+++ b/templates/architecture_interactive_forms/dir_tree_creator_form.md
@@ -1,0 +1,197 @@
+---
+asset_id: "<% tp.date.now('YYYYMMDDHHmm') %>_DIR_TREE_<% tp.file.title.replace(/\s+/g, '_').toUpperCase() %>"
+asset_name: "<% tp.file.title %>"
+asset_type: "dir_tree_form"
+asset_version: "1.0.0"
+asset_owner: "AingZ_Platform"
+asset_status: "draft"
+asset_tags:
+  - architecture
+  - dir-tree
+  - obsidian/form
+asset_created: "<% tp.date.now('YYYY-MM-DD') %>"
+asset_updated: "<% tp.date.now('YYYY-MM-DD') %>"
+context_scope: "platform"
+context_focus: "Definir, versionar y auditar árboles de directorios con assets requeridos."
+context_kpis:
+  - TreeCompleteness
+  - AssetAssignmentRate
+  - ReviewCycleTime
+compat_platforms:
+  - Obsidian
+  - VSCode
+  - GitHub
+  - Codex
+  - GPT5
+compat_plugins_required:
+  - Templater
+  - Buttons
+  - Dataview
+  - Excalidraw
+  - QuickAdd
+  - Tasks
+compat_plugins_optional:
+  - Tracker
+  - Canvas
+  - Projects
+ai_handshake_codex_mode: "structured_markdown"
+ai_handshake_codex_contract: "Sincronizar Mermaid y Excalidraw; registrar assets obligatorios por carpeta."
+ai_handshake_gpt5_mode: "reasoning_markdown"
+ai_handshake_gpt5_contract: "Evaluar impacto sistémico de cambios en el árbol y sugerir mejoras sostenibles."
+governance_ruleset: "[[ruleset/ruleset_master_v_1]]"
+goals_trace_log: "Documentar iteraciones en [[#70 · WK.log & Feedback]]."
+---
+
+# [[Formulario · Dir Tree Creator]]
+
+> [!summary] Navegación rápida
+> [[#00 · Setup]] · [[#10 · Horizonte & Alcance]] · [[#20 · Mermaid Blueprint]] · [[#30 · Excalidraw Sync]] · [[#40 · Assets por Carpeta]] · [[#50 · Validación & Checks]] · [[#60 · KPIs & Auditoría]] · [[#70 · WK.log & Feedback]]
+
+---
+
+## 00 · Setup
+
+```button
+name 🧭 Abrir dir tree existente en Excalidraw
+type command
+action Excalidraw:Open drawing
+color orange
+```
+
+```button
+name ✳️ Generar blueprint base Mermaid
+type command
+action QuickAdd:DirTree · Mermaid Blueprint
+color teal
+```
+
+```button
+name ♻️ Refrescar paneles
+type command
+action Dataview:Refresh current view
+color purple
+```
+
+- [ ] Confirmar ruta raíz del árbol: ` `
+- [ ] Definir repositorios afectados: ` `
+- [ ] Registrar stakeholders técnicos en [[#40 · Assets por Carpeta]].
+
+> [!hint] Ajusta los nombres de comandos `QuickAdd` y `Excalidraw` según tu vault.
+
+---
+
+## 10 · Horizonte & Alcance
+
+| Elemento | Detalle | Estado |
+| --- | --- | --- |
+| Propósito del árbol |  | - [ ] |
+| Alcance temporal |  | - [ ] |
+| Entornos implicados |  | - [ ] |
+| Dependencias críticas |  | - [ ] |
+
+> [!faq]- Preguntas guía
+> - ¿Qué equipos consumen este árbol?
+> - ¿Qué normas o baselines condicionan su estructura?
+> - ¿Cómo se coordinan Codex/GPT5 con revisores humanos?
+
+---
+
+## 20 · Mermaid Blueprint
+
+```mermaid
+flowchart TD
+    A[(Root)] --> B[Subcarpeta 1]
+    A --> C[Subcarpeta 2]
+    B --> D[(Asset requerido)]
+    C --> E[(Script clave)]
+```
+
+- [ ] Actualizar el diagrama anterior con la estructura real.
+- [ ] Documentar convenciones de nomenclatura bajo el diagrama.
+
+> [!tip] Duplica este bloque al versionar cambios significativos para mantener trazabilidad histórica.
+
+---
+
+## 30 · Excalidraw Sync
+
+> [!info] Enlaza el lienzo activo para edición colaborativa.
+
+![[<% tp.file.title %>.excalidraw]]
+
+- [ ] Sincronizar capas de Excalidraw con los nodos de Mermaid.
+- [ ] Añadir sticky notes con owners y SLAs por carpeta.
+- [ ] Exportar PNG/SVG y adjuntarlo en `attachments/` si se comparte externamente.
+
+---
+
+## 40 · Assets por Carpeta
+
+> [!todo]+ Matriz de requisitos
+> Lista cada carpeta con sus assets obligatorios, responsables y estado.
+
+| Carpeta | Asset requerido | Responsable | Estado | Notas |
+| --- | --- | --- | --- | --- |
+|  |  |  | - [ ] |  |
+|  |  |  | - [ ] |  |
+|  |  |  | - [ ] |  |
+
+```tasks
+not done
+path includes "<ruta raíz>"
+description includes "asset"
+```
+
+> [!warning] Mantén consistentes las etiquetas (`#dir-tree`, `#asset-mandatory`) para reportes automáticos.
+
+---
+
+## 50 · Validación & Checks
+
+- [ ] Cada carpeta tiene owner y plan de respaldo documentado.
+- [ ] Existe estrategia de versionado para scripts sensibles.
+- [ ] Las dependencias cruzadas están registradas en `README` locales.
+- [ ] Se notificó a Codex/GPT5 sobre cambios relevantes.
+
+```tracker
+searchType: task
+searchTarget: "#dir-tree"
+startDate: 2024-01-01
+endDate: 2024-12-31
+summary:
+  template: "Checks completados: {{count}}"
+```
+
+---
+
+## 60 · KPIs & Auditoría
+
+| KPI | Fórmula | Meta | Valor actual |
+| --- | --- | --- | --- |
+| TreeCompleteness | (# carpetas documentadas / # carpetas totales) | 100% |  |
+| AssetAssignmentRate | (# assets con owner / # assets totales) | 95% |  |
+| ReviewCycleTime | (fecha última revisión - fecha previa) | <= 14 días |  |
+
+```dataview
+TABLE file.link AS "Formulario", asset_status
+FROM "templates/architecture_interactive_forms"
+WHERE asset_type = "dir_tree_form" and file.name != this.file.name
+SORT file.mtime desc
+LIMIT 15
+```
+
+> [!note] Usa `asset_status` = `in_review`, `approved` o `deprecated` para facilitar los tableros.
+
+---
+
+## 70 · WK.log & Feedback
+
+- 📅 <% tp.date.now("YYYY-MM-DD HH:mm") %> · Responsable:  · Resumen:
+- 📅  · Responsable:  · Resumen:
+- 📅  · Responsable:  · Resumen:
+
+> [!tip] Etiqueta entradas relevantes con `#dir-tree-log` y enlaza decisiones clave al Legacy correspondiente.
+
+---
+
+> [!done] Al finalizar, actualiza `asset_status` a `approved` y archiva una copia inmutable del Mermaid y Excalidraw asociados.

--- a/templates/architecture_interactive_forms/legacy_reference_pool/README.md
+++ b/templates/architecture_interactive_forms/legacy_reference_pool/README.md
@@ -1,0 +1,42 @@
+---
+asset_id: "legacy_pool_architecture_forms_v1"
+asset_type: "reference_pool"
+asset_version: "1.0.0"
+asset_owner: "AingZ_Platform"
+asset_status: "active"
+asset_tags:
+  - architecture
+  - legacy
+  - reference
+asset_updated: "2024-09-30"
+---
+
+# Legacy Reference Pool · Formularios Arquitectura
+
+> [!info] Propósito
+> Centralizar anexos, decisiones históricas y snapshots vinculados a los formularios de arquitectura y dir tree para acelerar iteraciones futuras sin releer todo el repositorio.
+
+## Convenciones de carga
+
+| Campo | Requisito |
+| --- | --- |
+| Nombre de archivo | `YYYYMMDD_contexto_descriptivo.md` |
+| Frontmatter mínimo | `asset_id`, `asset_status`, `origen_repo`, `resumen` |
+| Enlaces recomendados | Wikilinks a rulesets, diagramas Excalidraw, commits relevantes |
+
+## Carpetas sugeridas
+
+- `decisions/` · Registro de decisiones con impacto arquitectónico.
+- `snapshots/` · Capturas Mermaid/Excalidraw versionadas.
+- `evidence/` · Adjuntos técnicos (logs, métricas, auditorías).
+
+> [!tip] Para activos grandes, almacenar en `attachments/` y enlazar mediante `![[path/to/file]]`.
+
+## Integraciones clave
+
+- `[[ruleset/ruleset_master_v_1]]`
+- `[[templates/master_template_proposals/legacy_reference_pool/README|Legacy Master Templates]]`
+- `[[templates/architecture_interactive_forms/obsidian_architecture_master_form|Formulario Maestro Arquitectura]]`
+- `[[templates/architecture_interactive_forms/dir_tree_creator_form|Dir Tree Creator]]`
+
+> [!warning] Mantén `asset_status` actualizado (`active`, `deprecated`, `archived`) para permitir consultas Dataview globales.

--- a/templates/architecture_interactive_forms/obsidian_architecture_master_form.md
+++ b/templates/architecture_interactive_forms/obsidian_architecture_master_form.md
@@ -1,0 +1,234 @@
+asset_id: "<% tp.date.now('YYYYMMDDHHmm') %>_ARCH_FORM_<% tp.file.title.replace(/\s+/g, '_').toUpperCase() %>"
+asset_name: "<% tp.file.title %>"
+asset_type: "architecture_form"
+asset_version: "1.0.0"
+asset_owner: "AingZ_Platform"
+asset_status: "draft"
+asset_tags:
+  - architecture
+  - obsidian/form
+  - ai-collab
+asset_created: "<% tp.date.now('YYYY-MM-DD') %>"
+asset_updated: "<% tp.date.now('YYYY-MM-DD') %>"
+context_scope: "platform"
+context_repo_primary: "AingZ_Platform · https://github.com/AingZ/AingZ_Platform"
+context_mission: "Orquestar la arquitectura de la plataforma, directorios y assets críticos."
+context_kpis:
+  - ArchitectureCoverage
+  - FeedbackLoopTime
+  - AssetTraceability
+compat_platforms:
+  - Obsidian
+  - VSCode
+  - GitHub
+  - Codex
+  - GPT5
+compat_plugins_required:
+  - Templater
+  - Buttons
+  - Excalidraw
+  - Dataview
+  - Tasks
+  - Tracker
+compat_plugins_optional:
+  - Canvas
+  - Projects
+  - Periodic Notes
+ai_handshake_codex_mode: "structured_markdown"
+ai_handshake_codex_mandate: "Mantener bloques interactivos y wikilinks intactos; documentar comandos ejecutados."
+ai_handshake_gpt5_mode: "reasoning_markdown"
+ai_handshake_gpt5_mandate: "Explicar decisiones arquitectónicas y sus impactos en sostenibilidad y eficiencia."
+governance_ruleset: "[[ruleset/ruleset_master_v_1]]"
+governance_legacy_reference: "[[templates/architecture_interactive_forms/architecture_assets_inventory|Inventario Arquitectura]]"
+governance_change_log: "Registrar eventos clave en [[#80 · WK.log & Feedback]]."
+---
+
+# [[Formulario Maestro · Arquitectura Dinámica]]
+
+> [!summary] Navegación inmediata
+> [[#00 · Setup]] · [[#10 · Brief Arquitectónico]] · [[#20 · Directorios & Jerarquías]] · [[#30 · Assets & Contratos]] · [[#40 · Diagramación Excalidraw]] · [[#50 · Flujos & Automatización]] · [[#60 · Evaluación & KPIs]] · [[#80 · WK.log & Feedback]] · [[#99 · Checklist Final]]
+
+---
+
+## 00 · Setup
+
+```button
+name 🧭 Abrir diagrama Excalidraw existente
+type command
+action Excalidraw:Open drawing
+color orange
+```
+
+```button
+name ✳️ Crear copia de diagrama base
+type command
+action QuickAdd:Excalidraw · Nueva Arquitectura
+color teal
+```
+
+```button
+name ♻️ Refrescar paneles Dataview
+type command
+action Dataview:Refresh current view
+color purple
+```
+
+- [ ] Confirmar que el archivo Excalidraw activo está referenciado en [[#40 · Diagramación Excalidraw]].
+- [ ] Sincronizar los campos de `context.mission` y `context.kpis`.
+- [ ] Notificar al equipo AI (Codex/GPT5) sobre cambios estructurales en [[#80 · WK.log & Feedback]].
+
+> [!hint] Ajusta los nombres de comandos `QuickAdd`/`Excalidraw` según la configuración de tu vault.
+
+---
+
+## 10 · Brief Arquitectónico
+
+> [!quote] Contexto general
+> Describe la situación actual, restricciones técnicas y oportunidades clave.
+
+| Elemento | Detalle | Estado |
+| -------- | ------- | ------ |
+| Propósito principal |  | - [ ] |
+| Horizonte temporal |  | - [ ] |
+| Dependencias críticas |  | - [ ] |
+| Sostenibilidad (energía, cómputo, emisiones) |  | - [ ] |
+
+> [!faq]- Preguntas guía
+> - ¿Qué áreas de negocio cubre esta arquitectura?
+> - ¿Cuáles son los riesgos prioritarios a mitigar?
+> - ¿Cómo se integran los modelos Codex/GPT5 en el flujo?
+
+---
+
+## 20 · Directorios & Jerarquías
+
+> [!todo]+ Mapa del árbol de directorios
+> 1. Documenta el estado actual del árbol (`dir tree`).
+> 2. Marca cambios planificados versus ejecutados.
+> 3. Identifica propietarios para cada nodo crítico.
+
+### 20.1 · Snapshot actual
+
+```dataview
+TABLE file.folder AS "Ubicación", file.name AS "Recurso"
+FROM ""
+WHERE contains(file.folder, "<ruta/repositorio>")
+SORT file.folder ASC
+LIMIT 40
+```
+
+> [!warning] Personaliza la consulta anterior para apuntar al repositorio o carpeta objetivo antes de usarla.
+
+### 20.2 · Plan de evolución
+
+- [ ] Nodo principal:  → Responsable: 
+- [ ] Subsistema:  → Responsable: 
+- [ ] Carpeta crítica:  → Responsable: 
+- [ ] Scripts/Automation:  → Responsable: 
+
+> [!tip] Usa `tasks` con etiquetas (`#dir-update`) para que Dataview consolide acciones pendientes.
+
+---
+
+## 30 · Assets & Contratos
+
+| Asset | Ubicación | Responsable | Estado |
+| ----- | --------- | ----------- | ------ |
+|  |  |  | - [ ] |
+|  |  |  | - [ ] |
+|  |  |  | - [ ] |
+
+> [!example]- Referencias directas
+> - `[[templates/master_template_proposals/obsidian_master_template_aingz_master|Orbit·Spectrum V1]]`
+> - `[[templates/architecture_interactive_forms/architecture_assets_inventory|Inventario Arquitectura]]`
+> - `[[platform_arch_v5.excalidraw]]`
+
+```tasks
+not done
+path includes templates
+description includes "asset"
+```
+
+---
+
+## 40 · Diagramación Excalidraw
+
+> [!info] Conexión visual
+> Inserta el diagrama activo mediante wikilink para edición directa en Obsidian.
+
+![[platform_arch_v5.excalidraw]]
+
+- [ ] Actualizar diagrama con la fecha y versión del presente formulario.
+- [ ] Alinear capas/elementos con los nodos descritos en [[#20 · Directorios & Jerarquías]].
+- [ ] Adjuntar notas de decisiones relevantes usando sticky notes dentro de Excalidraw.
+
+> [!tip] Si generas un nuevo diagrama, reemplaza la referencia anterior por `![[<% tp.file.title %>.excalidraw]]`.
+
+---
+
+## 50 · Flujos & Automatización
+
+> [!todo]+ Modelado operativo
+> Lista los flujos de trabajo, automatizaciones y pipelines que impactan la arquitectura.
+
+| Flujo | Herramientas | Trigger | Estado |
+| ----- | ------------ | ------- | ------ |
+|  |  |  | - [ ] |
+|  |  |  | - [ ] |
+|  |  |  | - [ ] |
+
+```tracker
+searchType: task
+searchTarget: "#automation"
+startDate: 2024-01-01
+endDate: 2024-12-31
+summary:
+  template: "Automatizaciones completadas: {{count}}"
+```
+
+---
+
+## 60 · Evaluación & KPIs
+
+> [!hint] Calcula métricas clave para evaluar la arquitectura.
+
+| KPI | Fórmula | Valor actual | Responsable |
+| --- | ------- | ------------ | ----------- |
+| ArchitectureCoverage | (# nodos documentados / # nodos totales) |  |  |
+| FeedbackLoopTime | (fecha cierre - fecha apertura) |  |  |
+| AssetTraceability | (% assets con responsable asignado) |  |  |
+
+```dataview
+TABLE WITHOUT ID file.link AS "Formulario", asset_status AS "Estado"
+FROM "templates/architecture_interactive_forms"
+WHERE asset_type = "architecture_form" and file.name != this.file.name
+SORT file.ctime desc
+LIMIT 10
+```
+
+> [!warning] Requiere que las copias del formulario mantengan el frontmatter `asset_status` actualizado.
+
+---
+
+## 80 · WK.log & Feedback
+
+> [!abstract]+ Registro iterativo
+> Mantén trazabilidad de decisiones, acciones ejecutadas y feedback recibido.
+
+- 📅 <% tp.date.now("YYYY-MM-DD HH:mm") %> · Responsable:  · Resumen: 
+- 📅  · Responsable:  · Resumen: 
+- 📅  · Responsable:  · Resumen: 
+
+> [!tip] Etiqueta entradas relevantes con `#architecture-log` para consultas futuras.
+
+---
+
+## 99 · Checklist Final
+
+- [ ] Validar que todos los campos obligatorios estén completos.
+- [ ] Sincronizar decisiones en la base de conocimiento (`legacy_reference` o dashboards externos).
+- [ ] Compartir enlace y resumen con stakeholders clave.
+- [ ] Registrar lecciones aprendidas en [[templates/master_template_proposals/legacy_reference_pool/README|Legacy Reference Pool]].
+
+> [!done] Cuando todas las casillas estén marcadas, actualiza `asset_status` a `completed` y archiva una copia inmutable.
+

--- a/templates/master_template_proposals/README.md
+++ b/templates/master_template_proposals/README.md
@@ -1,0 +1,78 @@
+asset_id: obsidian_master_template_catalog_2025_09
+asset_name: ObsidianMasterTemplateCatalog
+asset_version: 1.0.0
+asset_owner: AingZ_Platform
+asset_status: validated
+context_domain: KnowledgeArchitecture
+context_goals:
+  - centralize_validated_master_template
+  - document_usage_contracts
+context_risks:
+  - drift_against_ruleset
+  - loss_of_interactive_blocks
+compat_platforms:
+  - Obsidian
+  - VSCode
+  - GitHub
+compat_connectors:
+  - Codex
+  - GPT5
+compat_notes: "Este índice refleja únicamente la versión validada del master template."
+---
+
+# Master Template Orbit·Spectrum V1 (Validado)
+
+- **Plantilla activa:** [[obsidian_master_template_aingz_master|A·Master Template · Orbit-Spectrum V1]]
+- **Última revisión:** <% tp.date.now('YYYY-MM-DD') %>
+- **Responsable de curaduría:** Equipo híbrido (AI Codex/GPT5 + humanos AingZ)
+
+> [!summary] ¿Por qué se consolidó esta versión?
+> - Integra el análisis de assets del repositorio y el legado curado en [[legacy_reference_pool/README|Legacy Reference Pool]].
+> - Maximiza interactividad Obsidian (Buttons, Dataview, Tasks, Tracker, Canvas, wikilinks).
+> - Contiene contratos explícitos para Codex y GPT5, garantizando reproducibilidad en múltiples plataformas (VSCode, GitHub, Obsidian).
+
+---
+
+## Cómo utilizar la plantilla
+
+1. Ejecutar `QuickAdd → MT · Nueva Nota` o `Templater → Insert template → A·Master Template · Orbit-Spectrum V1`.
+2. Completar la cabecera YAML antes de editar el cuerpo.
+3. Seguir las instrucciones en [[obsidian_master_template_aingz_master#00 · Setup Rápido]].
+4. Documentar cualquier personalización en [[obsidian_master_template_aingz_master#50 · Feedback y WK.log]] y, si aplica, anexar evidencia al [[legacy_reference_pool/README|Legacy Reference Pool]].
+
+> [!important] Política de actualización sin conflictos
+> - Antes de proponer cambios, sincroniza tu fork/branch con `main` y revisa si ya existe un archivo equivalente en el repositorio.
+> - **Nunca** dupliques archivos validados para introducir variaciones menores. En su lugar, edita la versión vigente y registra el razonamiento en [[obsidian_master_template_aingz_master#50 · Feedback y WK.log]].
+> - Si un flujo experimental requiere una nota alternativa, colócala en `legacy_reference_pool` con estado `experiment` y referencia explícita al asset original.
+
+---
+
+## Propuestas Next Gen en evaluación
+
+- Explora `[[next_gen_master_templates/README|Catálogo · Propuestas Next Gen]]` para comparar variantes **Nexus**, **Orbit Continuum** y **Spectrum Knowledge**.
+- Cada propuesta mantiene contratos AI↔humano y maximiza componentes interactivos para Obsidian, VSCode, GitHub y Codex/GPT5.
+- Registrar feedback comparativo en `[[next_gen_master_templates/README#Catálogo · Propuestas Next Gen]]` o directamente en cada plantilla dentro del bloque `Feedback`.
+
+> [!warning] Bloques protegidos
+> No eliminar callouts, botones, queries ni checklists definidos en la plantilla. Son necesarios para la colaboración AI↔humano.
+
+---
+
+## Mantenimiento y evolución
+
+- Cualquier ajuste mayor debe registrarse como propuesta en `legacy_reference_pool` antes de actualizar la versión validada.
+- Seguir los KPIs definidos en [[assets_landscape_analysis.md#7-kpi-propuestos-para-evaluar-adopción|KPIs de adopción]] para medir efectividad.
+- Cuando se valide una nueva iteración, actualizar este índice y mover la versión previa al repositorio histórico.
+
+---
+
+## Recursos vinculados
+
+| Recurso | Descripción | Uso |
+| ------- | ----------- | --- |
+| [[assets_landscape_analysis.md]] | Análisis integral de assets Markdown | Identificar requisitos y KPIs.
+| [[obsidian_master_template_aingz_master]] | Plantilla validada | Base obligatoria para nuevas notas.
+| [[legacy_reference_pool/README]] | Referencias históricas | Consultar experimentos y reglas previas.
+| [[context_packages/orbit_spectrum_master_template_context_pack_v1]] | Context pack operativo Orbit·Spectrum | Punto de partida para nuevas sesiones sin historial previo.
+
+> [!tip] Mantén sincronizado este índice con GitHub y Obsidian para que Codex/GPT5 accedan siempre a la versión oficial.

--- a/templates/master_template_proposals/assets_landscape_analysis.md
+++ b/templates/master_template_proposals/assets_landscape_analysis.md
@@ -1,0 +1,82 @@
+asset_id: repo_asset_landscape_obsidian_2025_09
+asset_name: ObsidianAssetLandscape
+asset_version: 1.1.0
+asset_owner: AingZ_Platform
+asset_status: validated
+context_domain: KnowledgeArchitecture
+context_goals:
+  - map_existing_markdown_assets
+  - derive_requirements_for_master_template
+context_risks:
+  - outdated_contracts
+  - inconsistent_front_matter
+compat_platforms:
+  - Obsidian
+  - GPT5
+  - CODEX
+compat_connectors:
+  - GitHub
+compat_notes: "Actualizado tras validar el master template Orbit·Spectrum V1."
+---
+
+# Panorama de assets Markdown vigentes
+
+> Objetivo: obtener una visión holística de los artefactos activos para fundamentar un nuevo master template compatible con Obsidian y los lineamientos V5.
+
+## 1. Baselines bloqueados
+
+| Ruta | Propósito | Observaciones clave |
+| ---- | --------- | ------------------- |
+| `core/doc/workbench/AINGZ_V5_Baselines_Unificados_v1_4_1_locked.md` | Consolidado normativo V5 | Define taxonomía y nomenclaturas, sirve como contrato fuente para semántica y jerarquías operativas. |
+| `core/doc/workbench/ruleset_baseline_v_1_locked.md` | RULESET base | Enfatiza contratos claros, unicidad de IDs y estructuras modulares RULE/SPEC/ENV/PRC. |
+| `core/doc/workbench/glossary_baseline_v_1_locked.md` | Glosario | Garantiza semántica única con definiciones inmutables, imprescindible para properties en Obsidian. |
+
+## 2. Rulesets y contratos activos
+
+- `ruleset/ruleset_master_v_1.md` establece las políticas unificadas para plataformas GPT, Codex, GitHub y Obsidian, incluyendo requisitos de front‑matter y OutputTemplate obligatorio.
+- `aing_z_ruleset_max_universal_v_1_0_template.md` codifica el contrato universal con cabecera YAML y jerarquía RULE/SPEC/ENV/PRC, reforzando evidencias, trazabilidad y seguridad.
+
+## 3. Knowledge packs y contextos operativos
+
+| Asset | Rol | Oportunidades para el master template |
+| ----- | --- | ------------------------------------- |
+| `chat_gpt_plus_knowledge_context_pack_v_1.md` | Paquete de contexto rápido | Estructura ligera con secciones de contexto y prompts; útil para callouts de misión y DO/DON'T. |
+| `codex_knowledge_context_pack_literal.md` | Contexto literal | Contiene enumeraciones y snippets reutilizables, ideal para secciones plegables (`> [!example]`) en la plantilla. |
+| `kb_obsidian_plugins_core_community_unificado_v_2025_09_02.md` | Inventario Obsidian | Lista plugins core/community activos, habilita uso de Dataview, Buttons, Tracker, Templater y Canvas como elementos soportados. |
+
+## 4. Recursos operativos complementarios
+
+- `test_suite_obsidian_plugins_core_community_v_1.md` documenta verificaciones sugeridas para plugins, relevante para checklists automatizadas.
+- `ruleset/context_pack_index.md` inventaría context packs y minipacks, mostrando conveniencia de tablas índice y enlaces cruzados.
+- `main/data_base` replica baselines en modo distribuido (`glossary`, `dir_tree`, `core_actv`), indicando necesidad de queries Dataview o `dataviewjs` para sincronización ligera dentro del vault.
+
+## 5. Requisitos derivados para el nuevo master template
+
+1. **Front‑matter estricto**: campos `asset`, `context`, `compat` alineados con RULESET_MAX.
+2. **Interactividad Obsidian**: compatibilidad con callouts, Tabs (cssclass), Dataview, Buttons y Canvas embeds.
+3. **Contratos visibles**: secciones para Inputs/Outputs, checkpoints y logging (`WK.log`).
+4. **Modos de vista**: bloques plegables para modo Focus, Resumen ejecutivo y Detalle técnico.
+5. **Instrumentación KPI**: tablas dinámicas y trackers para métricas de sostenibilidad e impacto.
+6. **Estrategia sin conflictos**: lineamientos explícitos para actualizar assets existentes (`asset_merge_strategy: inplace_update`) y registrar merges en `## 05 · Control de Versionado`.
+
+## 6. Master template validado
+
+- Plantilla oficial: [[obsidian_master_template_aingz_master]] (`status: validated`).
+- Origen: integración de aprendizajes de `legacy_reference_pool` + propuestas Orbit/Spectrum.
+- Diferenciadores clave:
+  - Contrato AI↔humano explícito (sección [[obsidian_master_template_aingz_master#01 · AI ↔ Humano Handshake]]).
+  - Interactividad ampliada (Buttons, Dataview, Tasks, Tracker, Canvas placeholders) con wikilinks para navegación Obsidian.
+  - KPIs y sostenibilidad incorporados en [[obsidian_master_template_aingz_master#40 · Impacto & Sostenibilidad]].
+
+## 7. KPI propuestos para evaluar adopción
+
+| KPI | Descripción | Métrica asociada |
+| --- | ----------- | ---------------- |
+| `TemplateCoverage` | % de notas nuevas que usan el master template | `#NotasTemplate / #NotasNuevas` (Dataview). |
+| `InteractionDepth` | Promedio de componentes interactivos utilizados por nota | Conteo de callouts, tasks y embeds. |
+| `SustainabilityTrace` | Notas con properties de impacto ambiental completadas | `dv.pages().where(p => p.impact_carbon)` |
+| `FeedbackLoopTime` | Tiempo desde creación a primera retroalimentación registrada | `date(first_feedback) - date(created)`. |
+
+---
+
+> Próximo paso: monitorear KPIs, registrar insights en `legacy_reference_pool` y, si es necesario, preparar una nueva propuesta para revisión formal.

--- a/templates/master_template_proposals/context_packages/orbit_spectrum_master_template_context_pack_v1.md
+++ b/templates/master_template_proposals/context_packages/orbit_spectrum_master_template_context_pack_v1.md
@@ -1,0 +1,104 @@
+---
+asset_id: orbit_spectrum_master_template_context_pack
+asset_name: OrbitSpectrumMasterTemplateContextPack
+asset_version: 1.0.0
+asset_owner: AingZ_Platform
+last_update: 2025-09-02
+compat_agents:
+  - Codex
+  - GPT5
+compat_platforms:
+  - Obsidian
+  - VSCode
+  - GitHub
+  - CodexCLI
+status: active
+---
+
+# Orbit·Spectrum Master Template · Context Pack v1.0
+
+> Paquete de contexto para iniciar nuevas iteraciones del [[obsidian_master_template_aingz_master|A·Master Template · Orbit-Spectrum V1]] sin releer el repositorio completo.
+
+---
+
+## 1. Propósito y alcance
+- Centralizar instrucciones operativas, contratos IA↔humano y enlaces críticos del master template validado.
+- Servir como punto de partida para nuevos hilos de trabajo con Codex o GPT5 en ausencia de historial previo.
+- Registrar avances confirmados y experimentos fallidos para evitar retrabajo.
+
+---
+
+## 2. Navegación esencial
+| Recurso | Descripción | Uso inmediato |
+|---------|-------------|----------------|
+| [[obsidian_master_template_aingz_master]] | Plantilla validada Orbit·Spectrum V1 | Insertar en notas nuevas (QuickAdd/Templater). |
+| [[next_gen_master_templates/README]] | Catálogo Nexus · Orbit Continuum · Spectrum | Referencia comparativa para futuras mejoras. |
+| [[legacy_reference_pool/README]] | Índice de legados y experimentos previos | Consultar decisiones históricas y anexos. |
+| [[assets_landscape_analysis.md]] | Análisis integral de assets Markdown | Validar KPIs y requisitos técnicos. |
+| [[context_packages/orbit_spectrum_master_template_context_pack_v1|Este context pack]] | Punto de partida para nuevas sesiones | Revisar antes de ejecutar cambios. |
+
+---
+
+## 3. Flujo recomendado según plataforma
+### 3.1 Obsidian
+1. Cargar plugins mínimos: Dataview, Templater, QuickAdd, Buttons, Tracker, Excalidraw, Tasks, Admonition.
+2. Ejecutar `QuickAdd → MT · Nueva Nota` o `Templater → Insert template → A·Master Template · Orbit-Spectrum V1`.
+3. Completar frontmatter y seguir la sección `[[obsidian_master_template_aingz_master#00 · Setup Rápido]]`.
+4. Documentar feedback en `## 50 · Feedback y WK.log` y anexar evidencias al `[[legacy_reference_pool/README]]`.
+
+### 3.2 VSCode / GitHub
+- Utilizar Markdown Preview para validar estructura y callouts.
+- Mantener la jerarquía `templates/master_template_proposals/` y actualizar README tras cada cambio.
+- Confirmar que los bloques de código y botones se conservan; no convertir wikilinks a enlaces planos.
+
+### 3.3 Codex / GPT5
+- Inyectar este context pack + plantilla objetivo en el prompt inicial.
+- Recordar que los bloques protegidos (`Buttons`, `Dataview`, `Tracker`) son obligatorios.
+- Registrar decisiones en `## 40 · Impacto` y escalar hallazgos al legacy pool cuando corresponda.
+
+---
+
+## 4. Contratos IA↔humano
+- **Handshake inicial**: respetar campos `ai_role`, `human_role`, `ruleset_anchor` definidos en el frontmatter.
+- **Tareas iterativas**: usar `## 20 · Flujo de trabajo` para coordinar entregas Codex/GPT5 ↔ humano.
+- **Feedback continuo**: consolidar aprendizajes en `## 50 · Feedback y WK.log` y etiquetar con fecha ISO.
+
+---
+
+## 5. Registro de avances y pruebas
+| Fecha | Acción | Resultado |
+|-------|--------|-----------|
+| 2025-09-02 | Validación del [[obsidian_master_template_aingz_master]] como base obligatoria. | ✅ Adoptado en README principal. |
+| 2025-09-02 | Creación del `legacy_reference_pool` dedicado a plantillas y ruleset. | ✅ Disponible para consultas rápidas. |
+| 2025-09-02 | Diseño Orbit·Spectrum Prime y propuestas Nexus/Orbit Continuum/Spectrum. | ✅ Listas para evaluación comparativa. |
+| 2025-09-02 | Automatización/Tests sobre bloques interactivos. | ⚠️ Pendiente: no se han ejecutado pruebas automatizadas; requiere validación manual en Obsidian. |
+
+> [!note] Pruebas negativas registradas
+> - No se ejecutaron tests automatizados; documentado para evitar suposiciones de cobertura.
+> - Falta validar botones y trackers en un vault limpio (tarea abierta).
+
+---
+
+## 6. Estrategia de contribución sin conflictos
+
+1. Antes de generar nuevas propuestas, sincroniza tu branch con `main` y revisa los archivos existentes en `templates/master_template_proposals`.
+2. Evita crear duplicados de plantillas validadas; en su lugar, edita el asset original y registra los cambios en `## 05 · Control de Versionado` del template.
+3. Si necesitas explorar alternativas, ubícalas en `legacy_reference_pool` con estado `experiment` e incluye un enlace de retorno al asset fuente.
+4. Documenta cualquier conflicto y su resolución en el bloque `## 50 · Feedback y WK.log` para que Codex y GPT5 conozcan el historial.
+
+> [!tip] Cuando trabajes con Codex o GPT5 en paralelo, usa `git status` + `git diff` antes de cerrar para confirmar que solo se tocaron archivos previamente existentes.
+
+---
+
+## 7. Próximos pasos sugeridos
+1. Auditar alineación con `ruleset/` y `core/doc/workbench` para incorporar requisitos faltantes.
+2. Desarrollar módulos derivados (Orbit proyectos, Spectrum conocimiento) en `[[next_gen_master_templates/README]]`.
+3. Configurar dashboard de KPIs (`TemplateCoverage`, `InteractionDepth`, `SustainabilityTrace`, `FeedbackLoopTime`).
+4. Registrar quincenalmente ajustes y aprendizajes en `legacy_reference_pool` siguiendo convención `YYYYMMDD_change_log.md`.
+
+---
+
+## 7. Historial de revisiones
+- **v1.0.0 (2025-09-02):** Primera publicación del context pack para el Master Template Orbit·Spectrum V1. Resume lineamientos operativos, recursos clave y pruebas pendientes.
+
+> Mantener este documento sincronizado con GitHub/Obsidian. Cualquier cambio debe ir acompañado de una anotación en `[[legacy_reference_pool/README]]` y actualización del índice principal.

--- a/templates/master_template_proposals/legacy_reference_pool/README.md
+++ b/templates/master_template_proposals/legacy_reference_pool/README.md
@@ -1,0 +1,26 @@
+# Legacy Reference Pool for Master Templates
+
+Este contenedor centraliza materiales históricos, reglas previas y artefactos de soporte relacionados con el desarrollo de los master templates y RULESET.
+
+## Propósito
+- Facilitar la consulta incremental sin reanalizar todo el repositorio.
+- Versionar lineamientos, experimentos y ejemplos relevantes para la evolución de la plantilla maestra.
+- Servir como punto de carga de anexos (`.md`, `.json`, `.canvas`, `.excalidraw`, etc.) que deban incorporarse en futuras iteraciones.
+
+## Convenciones de carga
+1. **Naming**: `YYYYMMDD_contexto_descripcion.md` (adaptar extensión según corresponda).
+2. **Frontmatter recomendado**:
+   ```yaml
+   legacy_ref: true
+   scope: [template, ruleset]
+   source: <origen>
+   notes: <detalle breve>
+   ```
+3. **Referencias cruzadas**: incluir enlaces de retorno hacia la versión activa del master template o al RULESET vigente.
+4. **Control de cambios**: resumir en la parte superior qué conocimiento aporta y si reemplaza documentos previos.
+
+## Workflow sugerido
+- Al incorporar nuevo material, registrar un breve changelog en `templates/master_template_proposals/README.md` dentro de la sección de notas futuras.
+- Utilizar este folder como staging para insights que la IA (Codex / ChatGPT) y el equipo humano puedan incorporar en sesiones de co-diseño.
+
+> Mantener el contenido curado y etiquetado para habilitar búsquedas rápidas desde Dataview (`WHERE legacy_ref = true`).

--- a/templates/master_template_proposals/next_gen_master_templates/README.md
+++ b/templates/master_template_proposals/next_gen_master_templates/README.md
@@ -1,0 +1,47 @@
+---
+asset_id: next_gen_master_templates_catalog_v1
+asset_name: NextGenMasterTemplatesCatalog
+asset_version: 1.0.0
+asset_owner: AingZ_Platform
+asset_status: in_review
+asset_tags:
+  - obsidian/master
+  - proposals
+asset_updated: "2024-09-30"
+context_domain: KnowledgeArchitecture
+context_mission: "Explorar formatos maestros con máxima interactividad Obsidian/Codex/GPT5."
+context_kpis:
+  - TemplateCoverage
+  - InteractionDepth
+  - SustainabilityTrace
+compat_platforms:
+  - Obsidian
+  - VSCode
+  - GitHub
+  - Codex
+  - GPT5
+compat_plugins_required:
+  - Dataview
+  - Templater
+  - Buttons
+  - QuickAdd
+  - Tracker
+  - Tasks
+compat_plugins_optional:
+  - Excalidraw
+  - Canvas
+  - Charts
+  - Projects
+---
+
+# Catálogo · Propuestas Next Gen
+
+| Plantilla | Enfoque | Estado |
+| --- | --- | --- |
+| [[nexus_master_template|Nexus Master Template]] | Orquestación integral estrategia ↔ ejecución | in_review |
+| [[orbit_continuum_template|Orbit Continuum Template]] | Ciclos iterativos de proyectos sostenibles | in_review |
+| [[spectrum_knowledge_template|Spectrum Knowledge Template]] | Gestión de conocimiento con trazabilidad avanzada | in_review |
+
+> [!info] Todas las propuestas conservan contratos AI↔humano compatibles con Codex y GPT5, y explotan botones, Dataview, Tabs, Tracker y widgets avanzados para Obsidian.
+
+> [!tip] Duplica estas plantillas dentro de un entorno de pruebas antes de adoptarlas como estándar definitivo.

--- a/templates/master_template_proposals/next_gen_master_templates/nexus_master_template.md
+++ b/templates/master_template_proposals/next_gen_master_templates/nexus_master_template.md
@@ -1,0 +1,178 @@
+---
+asset_id: "<% tp.date.now('YYYYMMDDHHmm') %>_NEXUS_<% tp.file.title.replace(/\s+/g, '_').toUpperCase() %>"
+asset_name: "<% tp.file.title %>"
+asset_type: "master_template_proposal"
+asset_version: "0.9.0"
+asset_owner: "AingZ_Platform"
+asset_status: "in_review"
+asset_tags:
+  - nexus
+  - strategy
+  - execution
+asset_created: "<% tp.date.now('YYYY-MM-DD') %>"
+asset_updated: "<% tp.date.now('YYYY-MM-DD') %>"
+context_domain: "Estrategia ↔ Ejecución"
+context_objectives:
+  - "Conectar visión estratégica con hojas de ruta operativas."
+  - "Mantener trazabilidad de impactos y sostenibilidad."
+ai_handshake_codex_mode: "structured_markdown"
+ai_handshake_codex_contract: "Respetar Tabs, callouts y tablas dinámicas; actualizar KPIs al cierre."
+ai_handshake_gpt5_mode: "reasoning_markdown"
+ai_handshake_gpt5_contract: "Evaluar decisiones frente a metas de sostenibilidad y autonomía."
+compat_platforms:
+  - Obsidian
+  - VSCode
+  - GitHub
+  - Codex
+  - GPT5
+compat_plugins_required:
+  - Templater
+  - Buttons
+  - Dataview
+  - Tabs
+  - Tracker
+  - Tasks
+compat_plugins_optional:
+  - Excalidraw
+  - Projects
+  - Canvas
+  - Charts
+---
+
+# [[Nexus Master Template · Estrategia Viva]]
+
+> [!summary] Flujo rápido
+> [[#00 · Setup]] · [[#01 · Handshake AI↔Humano]] · [[#10 · Contexto Estratégico]] · [[#20 · Roadmap Dinámico]] · [[#30 · Inteligencia & Insights]] · [[#40 · Impacto & Sostenibilidad]] · [[#50 · WK.log & Feedback]] · [[#60 · Checklist Final]]
+
+---
+
+## 00 · Setup
+
+```button
+name ➕ Instanciar Nota Hija
+type command
+action QuickAdd:Nexus · Nueva Nota Hija
+color blue
+```
+
+```button
+name ♻️ Refrescar Paneles
+type command
+action Dataview:Refresh current view
+color purple
+```
+
+- [ ] Nombrar archivo siguiendo `YYYYMMDD_tema_nexus`.
+- [ ] Confirmar objetivos estratégicos en [[#10 · Contexto Estratégico]].
+- [ ] Sincronizar roles con stakeholders humanos y Codex/GPT5.
+
+---
+
+## 01 · Handshake AI↔Humano
+
+| Actor | Rol | Mandato |
+| --- | --- | --- |
+| Codex | Arquitecto técnico | Mantener consistencia de estructuras y automatizaciones. |
+| GPT5 | Analista estratégico | Evaluar impactos de decisiones y registrar supuestos. |
+| Humano | Lead | Aprobar cambios críticos y consolidar feedback. |
+
+> [!info] Documenta cualquier ajuste de mandato directamente en la tabla anterior para mantener trazabilidad contractual.
+
+---
+
+## 10 · Contexto Estratégico
+
+```dataviewjs
+const perspective = dv.current().file.frontmatter.context_objectives ?? [];
+dv.paragraph(`**Objetivos declarados:** ${perspective.join('; ')}`);
+```
+
+| Pilar | Meta | Horizonte | Indicador | Estado |
+| --- | --- | --- | --- | --- |
+| Estrategia |  |  |  | - [ ] |
+| Producto |  |  |  | - [ ] |
+| Tecnología |  |  |  | - [ ] |
+| Personas |  |  |  | - [ ] |
+
+> [!question]- Exploración
+> - ¿Qué hipótesis críticas deben validarse?
+> - ¿Qué riesgos sistémicos amenazan la sostenibilidad?
+
+---
+
+## 20 · Roadmap Dinámico
+
+```tabs
+tab: Q1
+- [ ] Hito 1 · Owner:  · Fecha objetivo: 
+- [ ] Hito 2 · Owner:  · Fecha objetivo: 
+tab: Q2
+- [ ] Hito 3 · Owner:  · Fecha objetivo: 
+- [ ] Hito 4 · Owner:  · Fecha objetivo: 
+tab: Q3
+- [ ] Hito 5 · Owner:  · Fecha objetivo: 
+tab: Q4
+- [ ] Hito 6 · Owner:  · Fecha objetivo: 
+```
+
+> [!tip] Etiqueta tareas con `#nexus-roadmap` para análisis automático.
+
+---
+
+## 30 · Inteligencia & Insights
+
+```dataview
+TABLE file.link AS "Fuente", file.mtime AS "Última actualización"
+FROM ""
+WHERE contains(file.tags, "insight")
+SORT file.mtime desc
+LIMIT 8
+```
+
+> [!abstract]+ Insights clave
+> - Insight 1 → Implicancias:
+> - Insight 2 → Implicancias:
+> - Insight 3 → Implicancias:
+
+---
+
+## 40 · Impacto & Sostenibilidad
+
+| KPI | Fórmula | Meta | Valor | Responsable |
+| --- | --- | --- | --- | --- |
+| TemplateCoverage | (# notas alineadas / # notas totales) | 90% |  |  |
+| InteractionDepth | (# bloques interactivos usados / # bloques disponibles) | 80% |  |  |
+| SustainabilityTrace | (# decisiones con impacto documentado / total) | 100% |  |  |
+
+```tracker
+searchType: task
+searchTarget: "#sostenibilidad"
+startDate: 2024-01-01
+endDate: 2024-12-31
+summary:
+  template: "Acciones sostenibles completadas: {{count}}"
+```
+
+---
+
+## 50 · WK.log & Feedback
+
+- 📅 <% tp.date.now("YYYY-MM-DD HH:mm") %> · Actor:  · Evento:
+- 📅  · Actor:  · Evento:
+- 📅  · Actor:  · Evento:
+
+```tasks
+not done
+description includes "feedback"
+```
+
+---
+
+## 60 · Checklist Final
+
+- [ ] Roadmap actualizado y compartido.
+- [ ] KPIs revisados y registrados.
+- [ ] Feedback consolidado y acciones asignadas.
+- [ ] `asset_status` ajustado (`in_review`/`approved`).
+
+> [!done] Tras completarlo, sincronizar cambios en repositorios asociados y documentar en el Legacy correspondiente.

--- a/templates/master_template_proposals/next_gen_master_templates/orbit_continuum_template.md
+++ b/templates/master_template_proposals/next_gen_master_templates/orbit_continuum_template.md
@@ -1,0 +1,184 @@
+---
+asset_id: "<% tp.date.now('YYYYMMDDHHmm') %>_ORBIT_CONT_<% tp.file.title.replace(/\s+/g, '_').toUpperCase() %>"
+asset_name: "<% tp.file.title %>"
+asset_type: "master_template_proposal"
+asset_version: "0.9.0"
+asset_owner: "AingZ_Platform"
+asset_status: "in_review"
+asset_tags:
+  - orbit
+  - lifecycle
+  - sustainability
+asset_created: "<% tp.date.now('YYYY-MM-DD') %>"
+asset_updated: "<% tp.date.now('YYYY-MM-DD') %>"
+context_domain: "Ciclos de proyectos"
+context_objectives:
+  - "Asegurar stage-gates claros con métricas de sostenibilidad."
+  - "Integrar automatizaciones y feedback continuo."
+ai_handshake_codex_mode: "structured_markdown"
+ai_handshake_codex_contract: "Ejecutar y registrar acciones en Buttons/Tasks; mantener trackers alineados."
+ai_handshake_gpt5_mode: "reasoning_markdown"
+ai_handshake_gpt5_contract: "Evaluar decisiones de stage-gate con perspectiva sistémica."
+compat_platforms:
+  - Obsidian
+  - VSCode
+  - GitHub
+  - Codex
+  - GPT5
+compat_plugins_required:
+  - Buttons
+  - Dataview
+  - Tasks
+  - Tracker
+  - Excalidraw
+  - QuickAdd
+compat_plugins_optional:
+  - Tabs
+  - Projects
+  - Calendar
+  - Kanban
+---
+
+# [[Orbit Continuum Template · Ciclo Vivo]]
+
+> [!summary] Flujo de navegación
+> [[#00 · Setup]] · [[#05 · Orbit Stage Map]] · [[#10 · Discover]] · [[#20 · Design]] · [[#30 · Deploy]] · [[#40 · Sustain]] · [[#50 · KPI Orbit]] · [[#60 · Feedback Loop]]
+
+---
+
+## 00 · Setup
+
+```button
+name ⚙️ Crear Stage Note
+type command
+action QuickAdd:Orbit · Nueva Stage Note
+color teal
+```
+
+```button
+name 🧭 Abrir Canvas Orbit
+type command
+action Canvas:Open
+color orange
+```
+
+- [ ] Definir scope del ciclo actual.
+- [ ] Confirmar stakeholders y responsables.
+- [ ] Revisar reglas aplicables en [[ruleset/ruleset_master_v_1]].
+
+---
+
+## 05 · Orbit Stage Map
+
+```mermaid
+gantt
+    title Orbit Continuum
+    section Discover
+    Research :done, d1, 2024-09-01, 7d
+    section Design
+    Prototype :active, d2, 2024-09-08, 10d
+    section Deploy
+    Rollout :d3, after d2, 14d
+    section Sustain
+    Monitoring :d4, after d3, 14d
+```
+
+- [ ] Actualizar fechas según planificación real.
+- [ ] Documentar dependencias críticas en comentarios.
+
+---
+
+## 10 · Discover
+
+| Actividad | Responsable | Evidencia | Estado |
+| --- | --- | --- | --- |
+|  |  |  | - [ ] |
+|  |  |  | - [ ] |
+
+```tasks
+not done
+path includes "discover"
+```
+
+> [!note] Adjunta descubrimientos clave en `legacy_reference_pool/` o en evidencias locales.
+
+---
+
+## 20 · Design
+
+> [!todo]+ Artefactos esenciales
+> - [ ] Wireframes actualizados en Excalidraw: `![[<% tp.file.title %>_design.excalidraw]]`
+> - [ ] Documentación técnica en `/design/`
+> - [ ] Revisión de accesibilidad completada
+
+```dataview
+TABLE file.link AS "Asset", file.mtime AS "Actualizado"
+FROM ""
+WHERE contains(file.name, "design")
+SORT file.mtime desc
+LIMIT 6
+```
+
+---
+
+## 30 · Deploy
+
+| Item | Owner | Script/Automation | Estado |
+| --- | --- | --- | --- |
+|  |  |  | - [ ] |
+|  |  |  | - [ ] |
+
+```tasks
+not done
+path includes "deploy"
+```
+
+> [!warning] Verifica pipelines CI/CD antes de marcar como completado.
+
+---
+
+## 40 · Sustain
+
+- [ ] Implementar monitoreo (Grafana/Prometheus).
+- [ ] Ejecutar evaluación de emisiones/energía.
+- [ ] Planificar retroalimentación de usuarios.
+
+```tracker
+searchType: task
+searchTarget: "#orbit-sustain"
+startDate: 2024-01-01
+endDate: 2024-12-31
+summary:
+  template: "Acciones Sustain completadas: {{count}}"
+```
+
+---
+
+## 50 · KPI Orbit
+
+| KPI | Fórmula | Meta | Valor | Observaciones |
+| --- | --- | --- | --- | --- |
+| StageOnTime | (# stages on-time / total stages) | 95% |  |  |
+| FeedbackLoopTime | (fecha feedback - fecha deploy) | <= 7 días |  |  |
+| SustainabilityScore | (puntuación agregada auditoría) | >= 85 |  |  |
+
+```dataview
+TABLE file.link AS "Stage", asset_status
+FROM "templates/master_template_proposals/next_gen_master_templates"
+WHERE asset_type = "master_template_proposal" and contains(asset_tags, "orbit")
+LIMIT 5
+```
+
+---
+
+## 60 · Feedback Loop
+
+- 📅 <% tp.date.now("YYYY-MM-DD HH:mm") %> · Stage:  · Lección:
+- 📅  · Stage:  · Lección:
+
+```tasks
+not done
+description includes "retro"
+```
+
+> [!done] Al cierre del ciclo, actualizar `asset_status` y enviar resumen al Legacy correspondiente.

--- a/templates/master_template_proposals/next_gen_master_templates/spectrum_knowledge_template.md
+++ b/templates/master_template_proposals/next_gen_master_templates/spectrum_knowledge_template.md
@@ -1,0 +1,172 @@
+---
+asset_id: "<% tp.date.now('YYYYMMDDHHmm') %>_SPECTRUM_<% tp.file.title.replace(/\s+/g, '_').toUpperCase() %>"
+asset_name: "<% tp.file.title %>"
+asset_type: "master_template_proposal"
+asset_version: "0.9.0"
+asset_owner: "AingZ_Platform"
+asset_status: "in_review"
+asset_tags:
+  - spectrum
+  - knowledge
+  - evidence
+asset_created: "<% tp.date.now('YYYY-MM-DD') %>"
+asset_updated: "<% tp.date.now('YYYY-MM-DD') %>"
+context_domain: "Gestión de conocimiento"
+context_objectives:
+  - "Curar conocimiento vivo con trazabilidad total."
+  - "Maximizar visualización Obsidian (Tabs, Canvas, Excalidraw)."
+ai_handshake_codex_mode: "structured_markdown"
+ai_handshake_codex_contract: "Mantener consultas Dataview/Tasks consistentes y registrar fuentes."
+ai_handshake_gpt5_mode: "reasoning_markdown"
+ai_handshake_gpt5_contract: "Analizar brechas de conocimiento y proponer acciones."
+compat_platforms:
+  - Obsidian
+  - VSCode
+  - GitHub
+  - Codex
+  - GPT5
+compat_plugins_required:
+  - Dataview
+  - Buttons
+  - QuickAdd
+  - Tasks
+  - Tracker
+  - Excalidraw
+compat_plugins_optional:
+  - Canvas
+  - Charts
+  - BRAT
+  - Citation
+---
+
+# [[Spectrum Knowledge Template · Matriz Viva]]
+
+> [!summary] Navegación principal
+> [[#00 · Setup]] · [[#05 · Handshake AI↔Humano]] · [[#10 · Contexto & Alcances]] · [[#20 · Fuentes & Evidencias]] · [[#30 · Canvas/Excalidraw]] · [[#40 · Insights & Acciones]] · [[#50 · KPIs & Coverage]] · [[#60 · Feedback & WK.log]]
+
+---
+
+## 00 · Setup
+
+```button
+name 📚 Indexar fuente
+type command
+action QuickAdd:Spectrum · Nueva Fuente
+color blue
+```
+
+```button
+name ♻️ Refrescar consultas
+type command
+action Dataview:Refresh current view
+color purple
+```
+
+- [ ] Definir taxonomía principal (`tags`).
+- [ ] Registrar reglas aplicables (`ruleset`).
+- [ ] Sincronizar assets gráficos con [[#30 · Canvas/Excalidraw]].
+
+---
+
+## 05 · Handshake AI↔Humano
+
+| Actor | Responsabilidad | Formato de entrega |
+| --- | --- | --- |
+| Codex | Normalizar fuentes y properties | Markdown estructurado + Dataview |
+| GPT5 | Analizar brechas y síntesis | Insight reasoning + KPIs |
+| Humano | Curador/a | Validar veracidad y actualizar Legacy |
+
+> [!tip] Ajusta la tabla según requerimientos específicos de tu equipo.
+
+---
+
+## 10 · Contexto & Alcances
+
+| Dominio | Límites | Stakeholders | Estado |
+| --- | --- | --- | --- |
+|  |  |  | - [ ] |
+|  |  |  | - [ ] |
+
+> [!question]- Guía
+> - ¿Qué knowledge packs se incluyen/excluyen?
+> - ¿Qué compromisos de actualización existen?
+
+---
+
+## 20 · Fuentes & Evidencias
+
+```dataview
+TABLE file.link AS "Fuente", file.folder AS "Ubicación", file.mtime AS "Actualizado"
+FROM ""
+WHERE contains(file.tags, "knowledge") or contains(file.tags, "evidence")
+SORT file.mtime desc
+LIMIT 12
+```
+
+```tasks
+not done
+description includes "evidencia"
+```
+
+> [!note] Anexa capturas, PDFs o datasets en `attachments/` y enlaza mediante `![[path/to/file]]`.
+
+---
+
+## 30 · Canvas/Excalidraw
+
+> [!info] Visualiza relaciones complejas mediante Canvas y Excalidraw.
+
+![[<% tp.file.title %>.canvas]]
+
+![[<% tp.file.title %>.excalidraw]]
+
+- [ ] Documentar cambios visuales con timestamp.
+- [ ] Coordinar con Codex para actualizar automatizaciones vinculadas.
+
+---
+
+## 40 · Insights & Acciones
+
+```tabs
+tab: Insights
+- Insight crítico · Impacto:
+- Insight emergente · Impacto:
+tab: Acciones
+- [ ] Acción 1 · Owner:  · Fecha objetivo:
+- [ ] Acción 2 · Owner:  · Fecha objetivo:
+```
+
+> [!tip] Utiliza etiquetas `#spectrum-insight` y `#spectrum-action` para rastrear desde Dataview.
+
+---
+
+## 50 · KPIs & Coverage
+
+| KPI | Fórmula | Meta | Valor |
+| --- | --- | --- | --- |
+| Coverage | (# fuentes catalogadas / total esperado) | 95% |  |
+| RefreshRate | (promedio días entre actualizaciones) | <= 10 |  |
+| EvidenceTrace | (# evidencias con fuente verificada / total) | 100% |  |
+
+```tracker
+searchType: task
+searchTarget: "#spectrum-action"
+startDate: 2024-01-01
+endDate: 2024-12-31
+summary:
+  template: "Acciones Spectrum completadas: {{count}}"
+```
+
+---
+
+## 60 · Feedback & WK.log
+
+- 📅 <% tp.date.now("YYYY-MM-DD HH:mm") %> · Evento:  · Resultado:
+- 📅  · Evento:  · Resultado:
+
+```tasks
+not done
+description includes "spectrum feedback"
+```
+
+> [!done] Actualiza `asset_status` y sincroniza con el Legacy tras cada ciclo de actualización.

--- a/templates/master_template_proposals/obsidian_master_template_aingz_master.md
+++ b/templates/master_template_proposals/obsidian_master_template_aingz_master.md
@@ -1,0 +1,277 @@
+asset_id: "<% tp.date.now('YYYYMMDDHHmm') %>_<% tp.file.title.replace(/\s+/g, '_').toUpperCase() %>"
+asset_name: "<% tp.file.title %>"
+asset_type: "master_template"
+asset_version: "1.0.0"
+asset_owner: "AingZ_Platform"
+asset_status: "validated"
+asset_merge_strategy: "inplace_update"
+asset_source_reference: "https://github.com/AingZ/AingZ_Platform/tree/main/templates/master_template_proposals"
+asset_tags:
+  - obsidian/master
+  - ai-collab
+  - sustainability
+asset_created: "<% tp.date.now('YYYY-MM-DD') %>"
+asset_updated: "<% tp.date.now('YYYY-MM-DD') %>"
+context_domain: ""
+context_mission: ""
+context_goals:
+  - ""
+context_stakeholders:
+  - "role: ; contact: "
+context_risks:
+  - ""
+compat_platforms:
+  - Obsidian
+  - VSCode
+  - GitHub
+  - Codex
+  - GPT5
+compat_plugins_required:
+  - Dataview
+  - Templater
+  - Buttons
+  - QuickAdd
+  - Tracker
+  - Tasks
+  - Calendar
+compat_plugins_optional:
+  - Canvas
+  - Excalidraw
+  - Projects
+  - BRAT
+  - Periodic Notes
+compat_notes: "Duplicar con Templater/QuickAdd antes de editar."
+ai_handshake_codex_mode: "structured_markdown"
+ai_handshake_codex_contract: "Mantener YAML, callouts y bloques interactivos intactos."
+ai_handshake_codex_prompts:
+  - "Responder con listas accionables"
+  - "Actualizar checklists y WK.log al final de cada intervención"
+ai_handshake_gpt5_mode: "reasoning_markdown"
+ai_handshake_gpt5_contract: "Explicar decisiones en [[#50 · Feedback y WK.log]] con timestamp."
+ai_handshake_gpt5_prompts:
+  - "Aplicar análisis sistémico con perspectiva de sostenibilidad"
+  - "Proponer optimizaciones cuantificables (KPIs)"
+governance_ruleset: "[[ruleset/ruleset_master_v_1]]"
+governance_reference_legacy: "[[templates/master_template_proposals/legacy_reference_pool/README|Legacy Reference Pool]]"
+governance_change_control: "Registrar decisiones estratégicas en [[#50 · Feedback y WK.log]]."
+---
+
+%% -------------------------------------------------------------
+%% Guía rápida: la IA (Codex / GPT5) y los humanos deben seguir
+%% estas instrucciones sin eliminar bloques estructurales.
+%% -------------------------------------------------------------
+
+# [[A·Master Template · Orbit-Spectrum V1]]
+
+> [!summary] Navegación inmediata
+> [[#00 · Setup Rápido]] · [[#01 · AI ↔ Humano Handshake]] · [[#02 · Contratos y Metadata]] · [[#10 · Contexto Estratégico]] · [[#20 · Flujo Operativo]] · [[#30 · Data & Inteligencia]] · [[#40 · Impacto & Sostenibilidad]] · [[#50 · Feedback y WK.log]] · [[#60 · Anexos & Referencias]] · [[#99 · Checklist de Cierre]]
+
+---
+
+## 00 · Setup Rápido
+
+> [!abstract]+ Activación inicial
+> 1. Renombrar la nota siguiendo `YYYYMMDD_<TemaClave>`.
+> 2. Ejecutar la acción QuickAdd `MT · Nueva Nota` para clonar propiedades comunes.
+> 3. Validar que los campos de [[#02 · Contratos y Metadata]] estén completos.
+
+```button
+name ➕ Instanciar Plantilla Hija
+type command
+action QuickAdd:MT · Nueva Nota Hija
+color blue
+```
+
+```button
+name ♻️ Refrescar Dataview
+type command
+action Dataview:Refresh current view
+color purple
+```
+
+- [ ] Confirmar que `ai_handshake` contiene las instrucciones vigentes.
+- [ ] Registrar responsables en `context.stakeholders`.
+- [ ] Sincronizar tags con la taxonomía del [[ruleset/ruleset_master_v_1]].
+
+> [!hint] Ajusta el campo `action` de cada botón según los IDs de comando disponibles en tu vault (`Settings → Buttons`).
+
+---
+
+## 01 · AI ↔ Humano Handshake
+
+> [!info] Codex
+> - Interpretar secciones tituladas con `##` como módulos independientes.
+> - No modificar frontmatter salvo que se solicite explícitamente.
+> - Documentar comandos ejecutados dentro de [[#50 · Feedback y WK.log]].
+> - Ejecutar `git status` antes de cerrar la sesión y confirmar que solo se modificaron archivos existentes.
+
+> [!tip] GPT5
+> - Mantener trazabilidad de decisiones en subtareas `- [ ]` y justificar cambios significativos.
+> - Antes de cerrar, completar el bloque [[#99 · Checklist de Cierre]] con hallazgos clave.
+
+> [!warning] Bloques protegidos
+> - No eliminar los bloques `button`, `dataview`, `tasks`, `tracker` ni las secciones con `%%`.
+> - Respetar los wikilinks internos (`[[#Sección]]`) para asegurar navegabilidad en Obsidian.
+> - Si se requiere contenido nuevo, incorporarlo en secciones existentes o documentarlo en `legacy_reference_pool`.
+
+---
+
+## 02 · Contratos y Metadata
+
+> [!todo]+ Campos obligatorios (RULESET)
+> - `asset.domain`, `context.mission`, `compat.platforms`
+> - `governance.ruleset`, `governance.change_control`
+> - `ai_handshake` actualizado según el modo de colaboración.
+> - `asset_merge_strategy` debe mantenerse en `inplace_update` salvo aprobación explícita.
+
+| Campo | Descripción | Estado |
+| ----- | ----------- | ------ |
+| `mission` | Objetivo operativo principal | - [ ] |
+| `goals` | Metas cuantificables vinculadas a KPIs | - [ ] |
+| `risks` | Riesgos críticos con planes de mitigación | - [ ] |
+| `stakeholders` | Roles clave y responsables | - [ ] |
+
+> [!note] Sincronización automática
+> Usa el botón `♻️ Refrescar Dataview` tras editar frontmatter para actualizar paneles derivados.
+
+---
+
+## 05 · Control de Versionado y Sincronización
+
+> [!check]+ Pasos obligatorios antes de editar
+> - [ ] Ejecutar `git pull --rebase` o sincronizar vault (Obsidian Git) para traer cambios recientes.
+> - [ ] Revisar si existe una nota equivalente en `templates/master_template_proposals` para evitar duplicados.
+> - [ ] Registrar aquí la referencia del commit base: `Base commit: ____`.
+
+```dataview
+TABLE file.ctime as "Creado", file.mtime as "Última edición", file.path as "Ruta"
+FROM "templates/master_template_proposals"
+WHERE file.name = this.file.name
+```
+
+> [!tip]
+> Documenta merge manuales o conflictos resueltos y enlaza al diff correspondiente en GitHub para trazabilidad colectiva.
+
+---
+
+## 10 · Contexto Estratégico
+
+> [!quote] Narrativa
+> Resume el propósito, alcance y horizonte temporal del asset.
+
+> [!example]- Modo Ejecutivo
+> - Hito clave #1: _...
+> - Dependencias críticas: _...
+> - KPIs vinculados: `TemplateCoverage`, `InteractionDepth`.
+
+> [!faq]- Modo Profundo (plegable)
+> - ¿Qué supuestos guían este trabajo?
+> - ¿Cómo se relaciona con [[legacy_reference_pool/README|Legacy Reference Pool]]?
+> - ¿Qué recursos adicionales se necesitan?
+
+---
+
+## 20 · Flujo Operativo
+
+> [!todo]+ Stage Gates
+> 1. **Discovery** → [[#30 · Data & Inteligencia]]
+> 2. **Design** → prototipos en Canvas/Excalidraw (`![[canvas/<% tp.file.title %>.canvas]]`)
+> 3. **Delivery** → tareas operativas en lista siguiente
+> 4. **Sustain** → validación de KPIs y documentación final
+
+### 20.1 · Plan de tareas
+
+- [ ] Discovery · Investigación preliminar (responsable: )
+- [ ] Design · Construcción de solución (responsable: )
+- [ ] Delivery · Implementación / despliegue (responsable: )
+- [ ] Sustain · Seguimiento y ajustes (responsable: )
+
+```tasks
+not done
+path includes <% tp.file.title %>
+short mode
+group by filename
+sort by priority
+```
+
+> [!tip] Usa `QuickAdd` para crear subtareas siguiendo la convención `YYYYMMDD · Acción · Responsable`.
+
+---
+
+## 30 · Data & Inteligencia
+
+> [!info] Tablero Dataview
+> Visualiza notas relacionadas que comparten el mismo tag o `asset.id`.
+
+```dataview
+TABLE file.mtime as "Última edición", mission, status, impact_carbon
+FROM ""
+WHERE contains(file.tags, "obsidian/master") AND file.name != this.file.name
+SORT file.mtime DESC
+```
+
+> [!hint]- Integración externa
+> - Embed datasets relevantes: `![[data/<nombre_dataset>.csv]]`
+> - Usa `dataviewjs` para cálculos personalizados si se requieren métricas avanzadas.
+
+---
+
+## 40 · Impacto & Sostenibilidad
+
+> [!todo]+ Indicadores principales
+> - `impact_carbon` (kg CO2e)
+> - `impact_water` (L)
+> - `impact_social` (breve descripción)
+
+```tracker
+searchType: dvField
+searchTarget: impact_carbon
+datasetName: "Huella de Carbono"
+accumulation: sum
+startDate: <% tp.date.now('YYYY-MM-01') %>
+endDate: <% tp.date.now('YYYY-MM-DD') %>
+lineChart:
+    title: "Tendencia mensual"
+```
+
+> [!warning] Si algún indicador supera el umbral pactado en [[ruleset/ruleset_master_v_1]], activar plan de mitigación y documentarlo en [[#50 · Feedback y WK.log]].
+
+---
+
+## 50 · Feedback y WK.log
+
+> [!note] Registrar cada intervención de IA/humano con timestamp ISO8601.
+
+| Fecha/Hora | Autor | Rol | Resumen | Próximo paso |
+| ---------- | ----- | --- | ------- | ------------- |
+| <% tp.date.now('YYYY-MM-DDTHH:mm') %> |  |  |  |  |
+
+> [!todo]- Retroalimentación pendiente
+> - [ ] Validar entregables con responsables humanos
+> - [ ] Documentar aprendizajes clave en RULESET o Legacy si aplica
+
+---
+
+## 60 · Anexos & Referencias
+
+> [!tip] Recursos vinculados
+> - [[ruleset/ruleset_master_v_1]] (contrato vigente)
+> - [[aing_z_ruleset_max_universal_v_1_0_template]]
+> - [[templates/master_template_proposals/legacy_reference_pool/README|Legacy Reference Pool]]
+> - ![[canvas/<% tp.file.title %> · mapa.canvas]] *(crear si se necesita visualización)*
+
+> [!example]- Evidencias multimedia
+> - Capturas: `![[evidence/<% tp.date.now('YYYYMMDD') %>_screenshot.png]]`
+> - Audio/Video: `![[evidence/<% tp.date.now('YYYYMMDD') %>_brief.mp4]]`
+
+---
+
+## 99 · Checklist de Cierre
+
+- [ ] WK.log actualizado y compartido
+- [ ] KPIs revisados y en rango
+- [ ] Feedback integrado al [[templates/master_template_proposals/legacy_reference_pool/README|Legacy Reference Pool]] si aplica
+- [ ] Estado final comunicado (Codex/GPT5 + humano)
+- [ ] Nota archivada o marcada como `status: completed`
+
+> [!success] Cuando todos los checks estén completos, actualizar `asset_status` a `completed` y mover la nota al archivo correspondiente.


### PR DESCRIPTION
## Summary
- expand the repository README with a context navigation checklist for Codex/GPT5 and human collaborators
- highlight the architecture form package and dir tree baseline converted from Excalidraw for continued development
- catalog the key template and legacy reference pools so future sessions can follow the instructions without ambiguity

## Testing
- no automated tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d547789d6083299e92f88911f8c32b